### PR TITLE
Accept and store image for dashboard content

### DIFF
--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -12,6 +12,7 @@ class Api::DashboardsController < ApiController
   def create
     dashboard = Dashboard.new(dashboard_params_create)
     if dashboard.save
+      dashboard.manage_content(request.base_url)
       render json: dashboard, status: :created
     else
       render_error(dashboard, :unprocessable_entity)
@@ -20,6 +21,7 @@ class Api::DashboardsController < ApiController
 
   def update
     if @dashboard.update_attributes(dashboard_params_update)
+      @dashboard.manage_content(request.base_url)
       render json: @dashboard, status: :ok
     else
       render_error(@dashboard, :unprocessable_entity)

--- a/app/models/content_image.rb
+++ b/app/models/content_image.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: content_images
+#
+#  id                 :integer          not null, primary key
+#  dashboard_id       :integer
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  image_file_name    :string
+#  image_content_type :string
+#  image_file_size    :integer
+#  image_updated_at   :datetime
+#
+
+class ContentImage < ApplicationRecord
+  belongs_to :dashboard
+  
+  has_attached_file :image, styles: { cover: '1280x800>', thumb: '110x110>' }
+  validates_attachment_content_type :image, content_type: %r{^image\/.*}
+end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: profiles
+#
+#  id                  :integer          not null, primary key
+#  user_id             :string
+#  avatar_file_name    :string
+#  avatar_content_type :string
+#  avatar_file_size    :integer
+#  avatar_updated_at   :datetime
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
 class Profile < ApplicationRecord
   has_attached_file :avatar, styles: { medium: '300x300>', thumbnail: '100x100>' }
   validates_attachment_content_type :avatar, content_type: %r{^image\/.*}

--- a/app/models/tool.rb
+++ b/app/models/tool.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: tools
+#
+#  id                     :integer          not null, primary key
+#  title                  :string
+#  slug                   :string
+#  summary                :string
+#  description            :string
+#  content                :text
+#  url                    :string
+#  thumbnail_file_name    :string
+#  thumbnail_content_type :string
+#  thumbnail_file_size    :integer
+#  thumbnail_updated_at   :datetime
+#  published              :boolean
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+
 class Tool < ApplicationRecord
   extend FriendlyId
   friendly_id :title, use: %i(slugged)

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
-# Table name: static_pages
+# Table name: profiles
 #
-#  user_id             :string          not null, primary key
+#  id                  :integer          not null, primary key
+#  user_id             :string
 #  avatar_file_name    :string
 #  avatar_content_type :string
 #  avatar_file_size    :integer
 #  avatar_updated_at   :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
-#  published           :boolean
 #
 
 # Profile Serializer

--- a/app/serializers/tool_serializer.rb
+++ b/app/serializers/tool_serializer.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
-
 # == Schema Information
 #
-# Table name: static_pages
+# Table name: tools
 #
-#  id                 :integer          not null, primary key
-#  title              :string           not null
-#  summary            :text
-#  description        :text
-#  content            :text
+#  id                     :integer          not null, primary key
+#  title                  :string
+#  slug                   :string
+#  summary                :string
+#  description            :string
+#  content                :text
+#  url                    :string
 #  thumbnail_file_name    :string
 #  thumbnail_content_type :string
 #  thumbnail_file_size    :integer
 #  thumbnail_updated_at   :datetime
-#  slug               :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  published          :boolean
+#  published              :boolean
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #
 
 # Tool Serializer

--- a/db/migrate/20171121155605_create_content_images.rb
+++ b/db/migrate/20171121155605_create_content_images.rb
@@ -1,0 +1,9 @@
+class CreateContentImages < ActiveRecord::Migration[5.1]
+  def change
+    create_table :content_images do |t|
+      t.integer :dashboard_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20171121160003_add_attachment_to_content_image.rb
+++ b/db/migrate/20171121160003_add_attachment_to_content_image.rb
@@ -1,0 +1,5 @@
+class AddAttachmentToContentImage < ActiveRecord::Migration[5.1]
+  def change
+    add_attachment :content_images, :image 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171010090404) do
+ActiveRecord::Schema.define(version: 20171121160003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "content_images", force: :cascade do |t|
+    t.integer "dashboard_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "image_file_name"
+    t.string "image_content_type"
+    t.integer "image_file_size"
+    t.datetime "image_updated_at"
+  end
 
   create_table "dashboards", force: :cascade do |t|
     t.string "name"


### PR DESCRIPTION
Accept images for the content field of a dashboard, the content field is the stringfied version of a json and the images inside could be coming from a base64 encode or from an url (which in this case I don't have to worry about).

When it comes in a base64 format, save the image to the new `content_image` model and then replace the base64 from the content string with its url.

[Pivotal Task](https://www.pivotaltracker.com/story/show/153021536)