### PR TITLE
Grids can have null objects

### DIFF
--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -71,7 +71,7 @@ class Dashboard < ApplicationRecord
         contents = assign_content_image_url(contents, content_block, base_url)
       elsif content_block['type'] == 'grid'
         content_block['content'].each do |content|
-          if content['type'] == 'image'
+          if content && content['type'] == 'image'
             contents = assign_content_image_url(contents, content, base_url, is_grid = true, grid = content_block)
           end
         end


### PR DESCRIPTION
As we can have `null` object inside the grids, it would be better if we really check its presence before trying to navigate through the object.