### PR TITLE
Add is_highlighted field to dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 28/11/2019
+- Add `is_highlighted` field to dashboards
+
 # 26/11/2019
 - Add `application` field to dashboards
 - Add `application` field to topics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 28/11/2019
-- Add `is_highlighted` field to dashboards
+- Add `is-highlighted` field to dashboards
 
 # 26/11/2019
 - Add `application` field to dashboards

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -130,7 +130,7 @@ class Api::DashboardsController < ApiController
   end
 
   def ensure_is_admin_for_highlighting
-    return true if !request.params.dig('data', 'attributes', 'is-highlighted').present?
+    return true unless request.params.dig('data', 'attributes', 'is-highlighted').present?
     return true if request.params.dig('data', 'attributes', 'is-highlighted').present? and @user[:role].eql? "ADMIN"
     render json: {errors: [{status: '403', title: 'You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard'}]}, status: 403
   end

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -130,9 +130,9 @@ class Api::DashboardsController < ApiController
   end
 
   def ensure_is_admin_for_highlighting
-    return true if !request.params.dig('data', 'attributes', 'is_highlighted').present?
-    return true if request.params.dig('data', 'attributes', 'is_highlighted').present? and @user[:role].eql? "ADMIN"
-    render json: {errors: [{status: '403', title: 'You need to be an ADMIN to create/update the is_highlighted attribute of the dashboard'}]}, status: 403
+    return true if !request.params.dig('data', 'attributes', 'is-highlighted').present?
+    return true if request.params.dig('data', 'attributes', 'is-highlighted').present? and @user[:role].eql? "ADMIN"
+    render json: {errors: [{status: '403', title: 'You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard'}]}, status: 403
   end
 
   def get_user
@@ -140,7 +140,7 @@ class Api::DashboardsController < ApiController
   end
 
   def dashboard_params_get
-    params.permit(:name, :published, :private, :user, :application, :is_highlighted, user: [], :filter => [:published, :private, :user])
+    params.permit(:name, :published, :private, :user, :application, 'is-highlighted'.to_sym, user: [], :filter => [:published, :private, :user])
   end
 
   def dashboard_params_create

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -133,14 +133,14 @@ class Api::DashboardsController < ApiController
   end
 
   def dashboard_params_get
-    params.permit(:name, :published, :private, :user, :application, :is_highighted, user: [], :filter => [:published, :private, :user])
+    params.permit(:name, :published, :private, :user, :application, :is_highlighted, user: [], :filter => [:published, :private, :user])
   end
 
   def dashboard_params_create
     new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
     new_params = ActionController::Parameters.new(new_params)
     new_params.permit(:name, :description, :content, :published, :summary, :photo,
-                      :user_id, :private, :production, :preproduction, :staging, :is_highighted, application:[])
+                      :user_id, :private, :production, :preproduction, :staging, :is_highlighted, application:[])
   rescue
     nil
   end
@@ -149,7 +149,7 @@ class Api::DashboardsController < ApiController
     new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
     new_params = ActionController::Parameters.new(new_params)
     new_params.permit(:name, :description, :content, :published, :summary,
-                      :photo, :private, :production, :preproduction, :staging, :is_highighted, application:[])
+                      :photo, :private, :production, :preproduction, :staging, :is_highlighted, application:[])
   rescue
     nil
   end

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -132,7 +132,7 @@ class Api::DashboardsController < ApiController
   def ensure_is_admin_for_highlighting
     return true if !request.params.dig('data', 'attributes', 'is_highlighted').present?
     return true if request.params.dig('data', 'attributes', 'is_highlighted').present? and @user[:role].eql? "ADMIN"
-    render json: {errors: [{status: '403', title: 'You need to an ADMIN to create/update the is_highlighted attribute of the dashboard'}]}, status: 403
+    render json: {errors: [{status: '403', title: 'You need to be an ADMIN to create/update the is_highlighted attribute of the dashboard'}]}, status: 403
   end
 
   def get_user

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -7,6 +7,7 @@ class Api::DashboardsController < ApiController
   before_action :get_user, only: %i[index]
   before_action :ensure_user_has_requested_apps, only: [:create, :update]
   before_action :ensure_is_manager_or_admin, only: :update
+  before_action :ensure_is_admin_for_highlighting, only: [:create, :update]
 
   def index
     if params.include?('user.role') && @user&.dig('role').eql?('ADMIN')
@@ -126,6 +127,12 @@ class Api::DashboardsController < ApiController
     return true if @user[:role].eql? "MANAGER" and @dashboard[:user_id].eql? @user[:id]
 
     render json: {errors: [{status: '403', title: 'You need to be either ADMIN or MANAGER and own the dashboard to update it'}]}, status: 403
+  end
+
+  def ensure_is_admin_for_highlighting
+    return true if !request.params.dig('data', 'attributes', 'is_highlighted').present?
+    return true if request.params.dig('data', 'attributes', 'is_highlighted').present? and @user[:role].eql? "ADMIN"
+    render json: {errors: [{status: '403', title: 'You need to an ADMIN to create/update the is_highlighted attribute of the dashboard'}]}, status: 403
   end
 
   def get_user

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -133,14 +133,14 @@ class Api::DashboardsController < ApiController
   end
 
   def dashboard_params_get
-    params.permit(:name, :published, :private, :user, :application, user: [], :filter => [:published, :private, :user])
+    params.permit(:name, :published, :private, :user, :application, :is_highighted, user: [], :filter => [:published, :private, :user])
   end
 
   def dashboard_params_create
     new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
     new_params = ActionController::Parameters.new(new_params)
     new_params.permit(:name, :description, :content, :published, :summary, :photo,
-                      :user_id, :private, :production, :preproduction, :staging, application:[])
+                      :user_id, :private, :production, :preproduction, :staging, :is_highighted, application:[])
   rescue
     nil
   end
@@ -149,7 +149,7 @@ class Api::DashboardsController < ApiController
     new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
     new_params = ActionController::Parameters.new(new_params)
     new_params.permit(:name, :description, :content, :published, :summary,
-                      :photo, :private, :production, :preproduction, :staging, application:[])
+                      :photo, :private, :production, :preproduction, :staging, :is_highighted, application:[])
   rescue
     nil
   end

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -22,6 +22,7 @@
 #  preproduction      :boolean          default(FALSE)
 #  staging            :boolean          default(FALSE)
 #  application        :string           default(["\"rw\""]), not null, is an Array
+#  is_highlighted     :boolean          default(FALSE)
 #
 
 class Dashboard < ApplicationRecord
@@ -40,6 +41,7 @@ class Dashboard < ApplicationRecord
   do_not_validate_attachment_file_type :photo
 
   scope :by_application, ->(application) { where("?::varchar = ANY(application)", application) }
+  scope :by_is_highlighted, ->(is_highlighted) { where(is_highlighted: is_highlighted) }
   scope :by_published, ->(published) { where(published: published) }
   scope :by_private, ->(is_private) { where(private: is_private) }
   scope :by_user, ->(user) { where(user_id: user) }
@@ -59,6 +61,7 @@ class Dashboard < ApplicationRecord
     end
 
     dashboards = dashboards.by_application(options[:application]) if options[:application]
+    dashboards = dashboards.by_is_highlighted(options[:is_highlighted]) if options[:is_highlighted]
     dashboards = dashboards.by_published(options[:published]) if options[:published]
     dashboards = dashboards.by_private(options[:private]) if options[:private]
     dashboards = dashboards.by_user(options[:user]) if options[:user]

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -61,7 +61,7 @@ class Dashboard < ApplicationRecord
     end
 
     dashboards = dashboards.by_application(options[:application]) if options[:application]
-    dashboards = dashboards.by_is_highlighted(options[:is_highlighted]) if options[:is_highlighted]
+    dashboards = dashboards.by_is_highlighted(options['is-highlighted'.to_sym]) if options['is-highlighted'.to_sym]
     dashboards = dashboards.by_published(options[:published]) if options[:published]
     dashboards = dashboards.by_private(options[:private]) if options[:private]
     dashboards = dashboards.by_user(options[:user]) if options[:user]

--- a/app/serializers/dashboard_serializer.rb
+++ b/app/serializers/dashboard_serializer.rb
@@ -22,12 +22,14 @@
 #  preproduction      :boolean          default(FALSE)
 #  staging            :boolean          default(FALSE)
 #  application        :string           default(["\"rw\""]), not null, is an Array
+#  is_highlighted     :boolean          default(FALSE)
 #
 
 class DashboardSerializer < ActiveModel::Serializer
   attributes :id, :name, :slug, :summary, :description,
              :content, :published, :photo, :user_id, :private,
-             :production, :preproduction, :staging, :user, :application
+             :production, :preproduction, :staging, :user, :application,
+             :is_highlighted
 
   def photo
     {

--- a/db/migrate/20191128104945_add_is_highlighted_field_to_dashboards.rb
+++ b/db/migrate/20191128104945_add_is_highlighted_field_to_dashboards.rb
@@ -1,0 +1,5 @@
+class AddIsHighlightedFieldToDashboards < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dashboards, :is_highlighted, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191126165002) do
+ActiveRecord::Schema.define(version: 20191128104945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20191126165002) do
     t.boolean "preproduction", default: false
     t.boolean "staging", default: false
     t.string "application", default: ["rw"], null: false, array: true
+    t.boolean "is_highlighted", default: false
   end
 
   create_table "faqs", force: :cascade do |t|

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -244,7 +244,7 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
     end
 
-    it 'with role ADMIN should create the dashboard providing the is_highlighted attrbiute' do
+    it 'with role ADMIN should create the dashboard providing the is-highlighted attrbiute' do
       post :create, params: {
         "data": {
           "type": "dashboards",
@@ -264,7 +264,7 @@ describe Api::DashboardsController, type: :controller do
             "application": [
               "rw"
             ],
-            "is_highlighted": true
+            "is-highlighted": true
           }
         },
         loggedUser: USERS[:ADMIN]
@@ -276,7 +276,7 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes]['is-highlighted'.to_sym]).to eq(true)
     end
 
-    it 'with role MANAGER should not create the dashboard providing the is_highlighted attrbiute' do
+    it 'with role MANAGER should not create the dashboard providing the is-highlighted attrbiute' do
       post :create, params: {
         "data": {
           "type": "dashboards",
@@ -296,7 +296,7 @@ describe Api::DashboardsController, type: :controller do
             "application": [
               "rw"
             ],
-            "is_highlighted": true
+            "is-highlighted": true
           }
         },
         loggedUser: USERS[:MANAGER]
@@ -305,7 +305,7 @@ describe Api::DashboardsController, type: :controller do
       expect(response.status).to eq(403)
     end
 
-    it 'with role USER should not create the dashboard providing the is_highlighted attrbiute' do
+    it 'with role USER should not create the dashboard providing the is-highlighted attrbiute' do
       post :create, params: {
         "data": {
           "type": "dashboards",
@@ -325,7 +325,7 @@ describe Api::DashboardsController, type: :controller do
             "application": [
               "rw"
             ],
-            "is_highlighted": true
+            "is-highlighted": true
           }
         },
         loggedUser: USERS[:USER]

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -244,7 +244,7 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
     end
 
-    it 'with role ADMIN should create the dashboard providing the is-highlighted attrbiute' do
+    it 'with role ADMIN should create the dashboard providing the is-highlighted attribute' do
       post :create, params: {
         "data": {
           "type": "dashboards",
@@ -276,7 +276,7 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes]['is-highlighted'.to_sym]).to eq(true)
     end
 
-    it 'with role MANAGER should not create the dashboard providing the is-highlighted attrbiute' do
+    it 'with role MANAGER should not create the dashboard providing the is-highlighted attribute' do
       post :create, params: {
         "data": {
           "type": "dashboards",
@@ -305,7 +305,7 @@ describe Api::DashboardsController, type: :controller do
       expect(response.status).to eq(403)
     end
 
-    it 'with role USER should not create the dashboard providing the is-highlighted attrbiute' do
+    it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
       post :create, params: {
         "data": {
           "type": "dashboards",

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -303,6 +303,13 @@ describe Api::DashboardsController, type: :controller do
       }
 
       expect(response.status).to eq(403)
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
+
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard")
+
     end
 
     it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
@@ -332,6 +339,12 @@ describe Api::DashboardsController, type: :controller do
       }
 
       expect(response.status).to eq(403)
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
+
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard")
     end
   end
 end

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -243,5 +243,95 @@ describe Api::DashboardsController, type: :controller do
 
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
     end
+
+    it 'with role ADMIN should create the dashboard providing the is_highlighted attrbiute' do
+      post :create, params: {
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "name": "Cities",
+            "summary": "test dashboard one summary",
+            "description": "Dashboard that uses cities",
+            "content": "test dashboard one description",
+            "published": true,
+            "photo": {
+              "cover": "/photos/cover/missing.png",
+              "thumb": "/photos/thumb/missing.png",
+              "original": "/photos/original/missing.png"
+            },
+            "user-id": "57ac9f9e29309063404573a2",
+            "private": true,
+            "application": [
+              "rw"
+            ],
+            "is_highlighted": true
+          }
+        },
+        loggedUser: USERS[:ADMIN]
+      }
+
+      expect(response.status).to eq(201)
+      sampleDashboard = json_response[:data]
+      validate_dashboard_structure(sampleDashboard)
+      expect(sampleDashboard[:attributes]['is-highlighted'.to_sym]).to eq(true)
+    end
+
+    it 'with role MANAGER should not create the dashboard providing the is_highlighted attrbiute' do
+      post :create, params: {
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "name": "Cities",
+            "summary": "test dashboard one summary",
+            "description": "Dashboard that uses cities",
+            "content": "test dashboard one description",
+            "published": true,
+            "photo": {
+              "cover": "/photos/cover/missing.png",
+              "thumb": "/photos/thumb/missing.png",
+              "original": "/photos/original/missing.png"
+            },
+            "user-id": "57ac9f9e29309063404573a2",
+            "private": true,
+            "application": [
+              "rw"
+            ],
+            "is_highlighted": true
+          }
+        },
+        loggedUser: USERS[:MANAGER]
+      }
+
+      expect(response.status).to eq(403)
+    end
+
+    it 'with role USER should not create the dashboard providing the is_highlighted attrbiute' do
+      post :create, params: {
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "name": "Cities",
+            "summary": "test dashboard one summary",
+            "description": "Dashboard that uses cities",
+            "content": "test dashboard one description",
+            "published": true,
+            "photo": {
+              "cover": "/photos/cover/missing.png",
+              "thumb": "/photos/thumb/missing.png",
+              "original": "/photos/original/missing.png"
+            },
+            "user-id": "57ac9f9e29309063404573a2",
+            "private": true,
+            "application": [
+              "rw"
+            ],
+            "is_highlighted": true
+          }
+        },
+        loggedUser: USERS[:USER]
+      }
+
+      expect(response.status).to eq(403)
+    end
   end
 end

--- a/spec/controllers/api/dashboards_get_spec.rb
+++ b/spec/controllers/api/dashboards_get_spec.rb
@@ -19,10 +19,7 @@ describe Api::DashboardsController, type: :controller do
 
       expect(response.status).to eq(200)
       expect(json_response[:data].size).to eq(5)
-
-
       sampleDashboard = json_response[:data][0]
-
       validate_dashboard_structure(sampleDashboard)
     end
 
@@ -98,6 +95,26 @@ describe Api::DashboardsController, type: :controller do
       expect(data.size).to eq(3)
       expect(data.map { |dashboard| dashboard[:attributes][:published] }.uniq).to eq([true])
       expect(data.map { |dashboard| dashboard[:attributes][:private] }.uniq).to eq([false])
+    end
+
+    it 'with is_highlighted=true filter should return only highlighted dashboards' do
+      get :index, params: {is_highlighted: 'true'}
+
+      data = json_response[:data]
+
+      expect(response.status).to eq(200)
+      expect(data.size).to eq(1)
+      expect(data.map { |dashboard| dashboard[:attributes]['is-highlighted'.to_sym] }.uniq).to eq([true])
+    end
+
+    it 'with is_highlighted=false filter should return only non-highlighted dashboards' do
+      get :index, params: {is_highlighted: 'false'}
+
+      data = json_response[:data]
+
+      expect(response.status).to eq(200)
+      expect(data.size).to eq(4)
+      expect(data.map { |dashboard| dashboard[:attributes]['is-highlighted'.to_sym] }.uniq).to eq([false])
     end
 
     it 'with includes=user while not being logged in should return dashboards including user name and email address' do

--- a/spec/controllers/api/dashboards_get_spec.rb
+++ b/spec/controllers/api/dashboards_get_spec.rb
@@ -97,8 +97,8 @@ describe Api::DashboardsController, type: :controller do
       expect(data.map { |dashboard| dashboard[:attributes][:private] }.uniq).to eq([false])
     end
 
-    it 'with is_highlighted=true filter should return only highlighted dashboards' do
-      get :index, params: {is_highlighted: 'true'}
+    it 'with is-highlighted=true filter should return only highlighted dashboards' do
+      get :index, params: {'is-highlighted': true}
 
       data = json_response[:data]
 
@@ -107,8 +107,8 @@ describe Api::DashboardsController, type: :controller do
       expect(data.map { |dashboard| dashboard[:attributes]['is-highlighted'.to_sym] }.uniq).to eq([true])
     end
 
-    it 'with is_highlighted=false filter should return only non-highlighted dashboards' do
-      get :index, params: {is_highlighted: 'false'}
+    it 'with is-highlighted=false filter should return only non-highlighted dashboards' do
+      get :index, params: {'is-highlighted': false}
 
       data = json_response[:data]
 

--- a/spec/controllers/api/dashboards_update_spec.rb
+++ b/spec/controllers/api/dashboards_update_spec.rb
@@ -273,6 +273,13 @@ describe Api::DashboardsController, type: :controller do
       }
 
       expect(response.status).to eq(403)
+
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
+
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard")
     end
 
     it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
@@ -288,6 +295,13 @@ describe Api::DashboardsController, type: :controller do
       }
 
       expect(response.status).to eq(403)
+
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
+
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be either ADMIN or MANAGER and own the dashboard to update it")
     end
   end
 end

--- a/spec/controllers/api/dashboards_update_spec.rb
+++ b/spec/controllers/api/dashboards_update_spec.rb
@@ -242,7 +242,7 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
     end
 
-    it 'with role ADMIN should update the dashboard providing the is-highlighted attrbiute' do
+    it 'with role ADMIN should update the dashboard providing the is-highlighted attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
         "data": {
@@ -260,7 +260,7 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes]['is-highlighted'.to_sym]).to eq(true)
     end
 
-    it 'with role MANAGER should not create the dashboard providing the is-highlighted attrbiute' do
+    it 'with role MANAGER should not create the dashboard providing the is-highlighted attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
         "data": {
@@ -275,7 +275,7 @@ describe Api::DashboardsController, type: :controller do
       expect(response.status).to eq(403)
     end
 
-    it 'with role USER should not create the dashboard providing the is-highlighted attrbiute' do
+    it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
         "data": {

--- a/spec/controllers/api/dashboards_update_spec.rb
+++ b/spec/controllers/api/dashboards_update_spec.rb
@@ -242,13 +242,13 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
     end
 
-    it 'with role ADMIN should update the dashboard providing the is_highlighted attrbiute' do
+    it 'with role ADMIN should update the dashboard providing the is-highlighted attrbiute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
         "data": {
           "type": "dashboards",
           "attributes": {
-            "is_highlighted": true
+            "is-highlighted": true
           }
         },
         loggedUser: USERS[:ADMIN]
@@ -260,13 +260,13 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes]['is-highlighted'.to_sym]).to eq(true)
     end
 
-    it 'with role MANAGER should not create the dashboard providing the is_highlighted attrbiute' do
+    it 'with role MANAGER should not create the dashboard providing the is-highlighted attrbiute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
         "data": {
           "type": "dashboards",
           "attributes": {
-            "is_highlighted": true
+            "is-highlighted": true
           }
         },
         loggedUser: USERS[:MANAGER]
@@ -275,13 +275,13 @@ describe Api::DashboardsController, type: :controller do
       expect(response.status).to eq(403)
     end
 
-    it 'with role USER should not create the dashboard providing the is_highlighted attrbiute' do
+    it 'with role USER should not create the dashboard providing the is-highlighted attrbiute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
         "data": {
           "type": "dashboards",
           "attributes": {
-            "is_highlighted": true
+            "is-highlighted": true
           }
         },
         loggedUser: USERS[:USER]

--- a/spec/controllers/api/dashboards_update_spec.rb
+++ b/spec/controllers/api/dashboards_update_spec.rb
@@ -241,5 +241,53 @@ describe Api::DashboardsController, type: :controller do
 
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
     end
+
+    it 'with role ADMIN should update the dashboard providing the is_highlighted attrbiute' do
+      patch :update, params: {
+        id: @dashboard_private_manager[:id],
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "is_highlighted": true
+          }
+        },
+        loggedUser: USERS[:ADMIN]
+      }
+
+      expect(response.status).to eq(200)
+      sampleDashboard = json_response[:data]
+      validate_dashboard_structure(sampleDashboard)
+      expect(sampleDashboard[:attributes]['is-highlighted'.to_sym]).to eq(true)
+    end
+
+    it 'with role MANAGER should not create the dashboard providing the is_highlighted attrbiute' do
+      patch :update, params: {
+        id: @dashboard_private_manager[:id],
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "is_highlighted": true
+          }
+        },
+        loggedUser: USERS[:MANAGER]
+      }
+
+      expect(response.status).to eq(403)
+    end
+
+    it 'with role USER should not create the dashboard providing the is_highlighted attrbiute' do
+      patch :update, params: {
+        id: @dashboard_private_manager[:id],
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "is_highlighted": true
+          }
+        },
+        loggedUser: USERS[:USER]
+      }
+
+      expect(response.status).to eq(403)
+    end
   end
 end

--- a/spec/factories/dashboards.rb
+++ b/spec/factories/dashboards.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
     published { true }
     user_id { '1a10d7c6e0a37126611fd7a6' }
     application { ['rw'] }
+    is_highlighted { false }
     private { true }
   end
 
@@ -39,6 +40,7 @@ FactoryBot.define do
     published { true }
     user_id { '57a1ff091ebc1ad91d089bdc' }
     application { ['rw'] }
+    is_highlighted { true }
     private { true }
   end
 
@@ -47,6 +49,7 @@ FactoryBot.define do
     published { true }
     user_id { '5c143429f8d19932db9d06ea' }
     application { ['rw'] }
+    is_highlighted { false }
     private { true }
   end
 
@@ -55,6 +58,7 @@ FactoryBot.define do
     published { true }
     user_id { '57a1ff091ebc1ad91d089bdc' }
     application { %w(rw gfw) }
+    is_highlighted { false }
     private { false }
   end
 
@@ -63,6 +67,7 @@ FactoryBot.define do
     published { true }
     user_id { '5c143429f8d19932db9d06ea' }
     application { ['gfw'] }
+    is_highlighted { false }
     private { false }
   end
 
@@ -71,6 +76,7 @@ FactoryBot.define do
     published { true }
     user_id { '5c069855ccc46a6660a4be68' }
     application { ['gfw'] }
+    is_highlighted { false }
     private { false }
   end
 
@@ -79,6 +85,7 @@ FactoryBot.define do
     published { true }
     user_id { '5c143429f8d19932db9d06ea' }
     private { false }
+    is_highlighted { false }
     content { "[{\"id\":1520242542490,\"type\":\"text\",\"content\":\"\\u003cp\\u003eBiodiversity intro\\u003c/p\\u003e\"},{\"id\":1518109294215,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109371974,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109389591,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109424849,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}}]" }
   end
 end

--- a/spec/factories/dashboards.rb
+++ b/spec/factories/dashboards.rb
@@ -22,6 +22,7 @@
 #  preproduction      :boolean          default(FALSE)
 #  staging            :boolean          default(FALSE)
 #  application        :string           default(["\"rw\""]), not null, is an Array
+#  is_highlighted     :boolean          default(FALSE)
 #
 
 FactoryBot.define do

--- a/spec/support/dashboard_helpers.rb
+++ b/spec/support/dashboard_helpers.rb
@@ -19,4 +19,5 @@ def validate_dashboard_structure(expected)
   expect(expected[:attributes]).to have_key(:staging)
   expect(expected[:attributes]).to have_key(:user)
   expect(expected[:attributes]).to have_key(:application)
+  expect(expected[:attributes]).to have_key('is-highlighted'.to_sym)
 end


### PR DESCRIPTION
This PR adds the `is_highlighted` attribute to the Dashboards entity.

This is a boolean field that can only be edited by ADMIN users.

The corresponding PT task is: https://www.pivotaltracker.com/story/show/169809569