### PR TITLE
Add user photo to includes=user query param

### DIFF
--- a/app/helpers/user_serializer_helper.rb
+++ b/app/helpers/user_serializer_helper.rb
@@ -20,6 +20,7 @@ module UserSerializerHelper
     result = {
         name: user['name'],
         email: user['email'],
+        photo: user['photo'],
     }
 
     result[:role] = user['role'] if isAdmin

--- a/spec/controllers/api/dashboards_get_spec.rb
+++ b/spec/controllers/api/dashboards_get_spec.rb
@@ -130,7 +130,7 @@ describe Api::DashboardsController, type: :controller do
       expect(data.map { |dashboard| dashboard[:attributes]['is-highlighted'.to_sym] }.uniq).to eq([false])
     end
 
-    it 'with includes=user while not being logged in should return dashboards including user name and email address' do
+    it 'with includes=user while not being logged in should return dashboards including user name, email and photo' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user'}
 
@@ -140,12 +140,12 @@ describe Api::DashboardsController, type: :controller do
         expect(data.size).to eq(5)
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
-          expect(dashboard[:attributes][:user].keys).to eq([:name, :email])
+          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
         end
       end
     end
 
-    it 'with includes=user while being logged in as USER should return dashboards including user name and email address' do
+    it 'with includes=user while being logged in as USER should return dashboards including user name, email and photo' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user', loggedUser: USERS[:USER].to_json}
 
@@ -155,12 +155,12 @@ describe Api::DashboardsController, type: :controller do
         expect(data.size).to eq(5)
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
-          expect(dashboard[:attributes][:user].keys).to eq([:name, :email])
+          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
         end
       end
     end
 
-    it 'with includes=user while being logged in as MANAGER should return dashboards including user name and email address' do
+    it 'with includes=user while being logged in as MANAGER should return dashboards including user name, email and photo' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user', loggedUser: USERS[:MANAGER].to_json}
 
@@ -170,12 +170,12 @@ describe Api::DashboardsController, type: :controller do
         expect(data.size).to eq(5)
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
-          expect(dashboard[:attributes][:user].keys).to eq([:name, :email])
+          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
         end
       end
     end
 
-    it 'with includes=user while being logged in as ADMIN should return dashboards including user name, email address and role' do
+    it 'with includes=user while being logged in as ADMIN should return dashboards including user name, email, photo and role' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user', loggedUser: USERS[:ADMIN].to_json}
 
@@ -185,12 +185,12 @@ describe Api::DashboardsController, type: :controller do
         expect(data.size).to eq(5)
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
-          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :role])
+          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo, :role])
         end
       end
     end
 
-    it 'with includes=user while being logged in as ADMIN should return dashboards including user name, email address and role, even if only partial data is available' do
+    it 'with includes=user while being logged in as ADMIN should return dashboards including user name, email, photo and role, even if only partial data is available' do
       VCR.use_cassette("include_user_partial") do
         get :index, params: {includes: 'user', loggedUser: USERS[:ADMIN].to_json}
 

--- a/spec/controllers/api/dashboards_get_spec.rb
+++ b/spec/controllers/api/dashboards_get_spec.rb
@@ -141,6 +141,7 @@ describe Api::DashboardsController, type: :controller do
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
           expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
+          expect(dashboard[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -156,6 +157,7 @@ describe Api::DashboardsController, type: :controller do
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
           expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
+          expect(dashboard[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -171,6 +173,7 @@ describe Api::DashboardsController, type: :controller do
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
           expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
+          expect(dashboard[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -186,6 +189,7 @@ describe Api::DashboardsController, type: :controller do
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
           expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo, :role])
+          expect(dashboard[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -208,14 +212,17 @@ describe Api::DashboardsController, type: :controller do
         expect(responseDatasetOne[:attributes][:user][:name]).to eq('John Doe')
         expect(responseDatasetOne[:attributes][:user][:role]).to eq('ADMIN')
         expect(responseDatasetOne[:attributes][:user][:email]).to eq('john.doe@vizzuality.com')
+        expect(responseDatasetOne[:attributes][:user][:photo]).to be_url()
 
         expect(responseDatasetTwo[:attributes][:user][:name]).to eq(nil)
         expect(responseDatasetTwo[:attributes][:user][:role]).to eq('USER')
         expect(responseDatasetTwo[:attributes][:user][:email]).to eq('jane.poe@vizzuality.com')
+        expect(responseDatasetTwo[:attributes][:user][:photo]).to be_url()
 
         expect(responseDatasetThree[:attributes][:user][:name]).to eq('mark')
         expect(responseDatasetThree[:attributes][:user][:role]).to eq('USER')
         expect(responseDatasetThree[:attributes][:user][:email]).to eq(nil)
+        expect(responseDatasetThree[:attributes][:user][:photo]).to be_url()
       end
     end
 

--- a/spec/controllers/api/topics_get_spec.rb
+++ b/spec/controllers/api/topics_get_spec.rb
@@ -74,7 +74,7 @@ describe Api::TopicsController, type: :controller do
       expect(data.map { |topic| topic[:attributes][:private] }.uniq).to eq([false])
     end
 
-    it 'with includes=user while not being logged in should return dashboards including user name and email address' do
+    it 'with includes=user while not being logged in should return dashboards including user name, email and photo' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user'}
 
@@ -84,12 +84,12 @@ describe Api::TopicsController, type: :controller do
         expect(data.size).to eq(4)
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
-          expect(dashboard[:attributes][:user].keys).to eq([:name, :email])
+          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
         end
       end
     end
 
-    it 'with includes=user while being logged in as USER should return dashboards including user name and email address' do
+    it 'with includes=user while being logged in as USER should return dashboards including user name, email and photo' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user', loggedUser: USERS[:USER].to_json}
 
@@ -99,12 +99,12 @@ describe Api::TopicsController, type: :controller do
         expect(data.size).to eq(4)
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
-          expect(dashboard[:attributes][:user].keys).to eq([:name, :email])
+          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
         end
       end
     end
 
-    it 'with includes=user while being logged in as MANAGER should return dashboards including user name and email address' do
+    it 'with includes=user while being logged in as MANAGER should return dashboards including user name, email and photo' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user', loggedUser: USERS[:MANAGER].to_json}
 
@@ -114,12 +114,12 @@ describe Api::TopicsController, type: :controller do
         expect(data.size).to eq(4)
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
-          expect(dashboard[:attributes][:user].keys).to eq([:name, :email])
+          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
         end
       end
     end
 
-    it 'with includes=user while being logged in as ADMIN should return dashboards including user name, email address and role' do
+    it 'with includes=user while being logged in as ADMIN should return dashboards including user name, email, photo and role' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user', loggedUser: USERS[:ADMIN].to_json}
 
@@ -129,12 +129,12 @@ describe Api::TopicsController, type: :controller do
         expect(data.size).to eq(4)
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
-          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :role])
+          expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo, :role])
         end
       end
     end
 
-    it 'with includes=user while being logged in as ADMIN should return dashboards including user name, email address and role, even if only partial data is available' do
+    it 'with includes=user while being logged in as ADMIN should return dashboards including user name, email, photo and role, even if only partial data is available' do
       VCR.use_cassette("include_user_partial") do
         get :index, params: {includes: 'user', loggedUser: USERS[:ADMIN].to_json}
 
@@ -163,7 +163,7 @@ describe Api::TopicsController, type: :controller do
       end
     end
 
-    it 'with includes=user while not being logged in should return topics including user name and email address' do
+    it 'with includes=user while not being logged in should return topics including user name, email and photo' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user'}
 
@@ -173,12 +173,12 @@ describe Api::TopicsController, type: :controller do
         expect(data.size).to eq(4)
         expect(data.map { |topic| topic[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |topic|
-          expect(topic[:attributes][:user].keys).to eq([:name, :email])
+          expect(topic[:attributes][:user].keys).to eq([:name, :email, :photo])
         end
       end
     end
 
-    it 'with includes=user while being logged in as USER should return topics including user name and email address' do
+    it 'with includes=user while being logged in as USER should return topics including user name, email and photo' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user', loggedUser: USERS[:USER].to_json}
 
@@ -188,12 +188,12 @@ describe Api::TopicsController, type: :controller do
         expect(data.size).to eq(4)
         expect(data.map { |topic| topic[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |topic|
-          expect(topic[:attributes][:user].keys).to eq([:name, :email])
+          expect(topic[:attributes][:user].keys).to eq([:name, :email, :photo])
         end
       end
     end
 
-    it 'with includes=user while being logged in as MANAGER should return topics including user name and email address' do
+    it 'with includes=user while being logged in as MANAGER should return topics including user name, email and photo' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user', loggedUser: USERS[:MANAGER].to_json}
 
@@ -203,12 +203,12 @@ describe Api::TopicsController, type: :controller do
         expect(data.size).to eq(4)
         expect(data.map { |topic| topic[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |topic|
-          expect(topic[:attributes][:user].keys).to eq([:name, :email])
+          expect(topic[:attributes][:user].keys).to eq([:name, :email, :photo])
         end
       end
     end
 
-    it 'with includes=user while being logged in as ADMIN should return topics including user name, email address and role' do
+    it 'with includes=user while being logged in as ADMIN should return topics including user name, email, photo and role' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user', loggedUser: USERS[:ADMIN].to_json}
 
@@ -218,12 +218,12 @@ describe Api::TopicsController, type: :controller do
         expect(data.size).to eq(4)
         expect(data.map { |topic| topic[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |topic|
-          expect(topic[:attributes][:user].keys).to eq([:name, :email, :role])
+          expect(topic[:attributes][:user].keys).to eq([:name, :email, :photo, :role])
         end
       end
     end
 
-    it 'with includes=user while being logged in as ADMIN should return topics including user name, email address and role, even if only partial data is available' do
+    it 'with includes=user while being logged in as ADMIN should return topics including user name, email, photo and role, even if only partial data is available' do
       VCR.use_cassette("include_user_partial") do
         get :index, params: {includes: 'user', loggedUser: USERS[:ADMIN].to_json}
 

--- a/spec/controllers/api/topics_get_spec.rb
+++ b/spec/controllers/api/topics_get_spec.rb
@@ -85,6 +85,7 @@ describe Api::TopicsController, type: :controller do
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
           expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
+          expect(dashboard[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -100,6 +101,7 @@ describe Api::TopicsController, type: :controller do
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
           expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
+          expect(dashboard[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -115,6 +117,7 @@ describe Api::TopicsController, type: :controller do
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
           expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo])
+          expect(dashboard[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -130,6 +133,7 @@ describe Api::TopicsController, type: :controller do
         expect(data.map { |dashboard| dashboard[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |dashboard|
           expect(dashboard[:attributes][:user].keys).to eq([:name, :email, :photo, :role])
+          expect(dashboard[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -152,14 +156,17 @@ describe Api::TopicsController, type: :controller do
         expect(responseDatasetOne[:attributes][:user][:name]).to eq('John Doe')
         expect(responseDatasetOne[:attributes][:user][:role]).to eq('ADMIN')
         expect(responseDatasetOne[:attributes][:user][:email]).to eq('john.doe@vizzuality.com')
+        expect(responseDatasetOne[:attributes][:user][:photo]).to be_url()
 
         expect(responseDatasetTwo[:attributes][:user][:name]).to eq(nil)
         expect(responseDatasetTwo[:attributes][:user][:role]).to eq('USER')
         expect(responseDatasetTwo[:attributes][:user][:email]).to eq('jane.poe@vizzuality.com')
+        expect(responseDatasetTwo[:attributes][:user][:photo]).to be_url()
 
         expect(responseDatasetThree[:attributes][:user][:name]).to eq('mark')
         expect(responseDatasetThree[:attributes][:user][:role]).to eq('USER')
         expect(responseDatasetThree[:attributes][:user][:email]).to eq(nil)
+        expect(responseDatasetThree[:attributes][:user][:photo]).to be_url()
       end
     end
 
@@ -174,6 +181,7 @@ describe Api::TopicsController, type: :controller do
         expect(data.map { |topic| topic[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |topic|
           expect(topic[:attributes][:user].keys).to eq([:name, :email, :photo])
+          expect(topic[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -189,6 +197,7 @@ describe Api::TopicsController, type: :controller do
         expect(data.map { |topic| topic[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |topic|
           expect(topic[:attributes][:user].keys).to eq([:name, :email, :photo])
+          expect(topic[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -204,6 +213,7 @@ describe Api::TopicsController, type: :controller do
         expect(data.map { |topic| topic[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |topic|
           expect(topic[:attributes][:user].keys).to eq([:name, :email, :photo])
+          expect(topic[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -219,6 +229,7 @@ describe Api::TopicsController, type: :controller do
         expect(data.map { |topic| topic[:attributes][:user].length }.uniq).not_to eq([0])
         data.each do |topic|
           expect(topic[:attributes][:user].keys).to eq([:name, :email, :photo, :role])
+          expect(topic[:attributes][:user][:photo]).to be_url()
         end
       end
     end
@@ -241,14 +252,17 @@ describe Api::TopicsController, type: :controller do
         expect(responseDatasetOne[:attributes][:user][:name]).to eq('John Doe')
         expect(responseDatasetOne[:attributes][:user][:role]).to eq('ADMIN')
         expect(responseDatasetOne[:attributes][:user][:email]).to eq('john.doe@vizzuality.com')
+        expect(responseDatasetOne[:attributes][:user][:photo]).to be_url()
 
         expect(responseDatasetTwo[:attributes][:user][:name]).to eq(nil)
         expect(responseDatasetTwo[:attributes][:user][:role]).to eq('USER')
         expect(responseDatasetTwo[:attributes][:user][:email]).to eq('jane.poe@vizzuality.com')
+        expect(responseDatasetTwo[:attributes][:user][:photo]).to be_url()
 
         expect(responseDatasetThree[:attributes][:user][:name]).to eq('mark')
         expect(responseDatasetThree[:attributes][:user][:role]).to eq('USER')
         expect(responseDatasetThree[:attributes][:user][:email]).to eq(nil)
+        expect(responseDatasetThree[:attributes][:user][:photo]).to be_url()
       end
     end
 

--- a/spec/support/matchers/url_matcher.rb
+++ b/spec/support/matchers/url_matcher.rb
@@ -1,0 +1,12 @@
+# Drop this into /spec/support/matchers
+# Usage: result.should be_url
+# Passes if result is a valid url, returns error "expected result to be url" if not.
+
+# Matcher to see if a string is a URL or not.
+RSpec::Matchers.define :be_url do |expected|
+	# The match method, returns true if valie, false if not.
+	match do |actual|
+		# Use the URI library to parse the string, returning false if this fails.
+		URI.parse(actual) rescue false
+	end
+end

--- a/spec/vcr_cassettes/include_user.yml
+++ b/spec/vcr_cassettes/include_user.yml
@@ -28,7 +28,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"data":[{"provider":"local","role":"ADMIN","_id":"57a1ff091ebc1ad91d089bdc","email":"john.doe@vizzuality.com","createdAt":"2016-08-03T14:26:17.014Z","extraUserData":{"apps":["rw","gfw","prep","aqueduct","forest-atlas","data4sdgs","aqueduct-water-risk"]}},{"provider":"local","role":"USER","_id":"5c143429f8d19932db9d06ea","email":"jane.poe@vizzuality.com","extraUserData":{"apps":[]},"createdAt":"2018-12-14T22:52:25.418Z","name":"jane","photo":""},{"provider":"local","role":"USER","_id":"5c069855ccc46a6660a4be68","email":"mark.twain@vizzuality.com","extraUserData":{"apps":[]},"createdAt":"2018-12-14T22:52:25.418Z","name":"mark","photo":""}]}'
+      string: '{"data":[{"provider":"local","role":"ADMIN","_id":"57a1ff091ebc1ad91d089bdc","email":"john.doe@vizzuality.com","createdAt":"2016-08-03T14:26:17.014Z","extraUserData":{"apps":["rw","gfw","prep","aqueduct","forest-atlas","data4sdgs","aqueduct-water-risk"]},"photo":"https://www.w3schools.com/howto/img_avatar.png"},{"provider":"local","role":"USER","_id":"5c143429f8d19932db9d06ea","email":"jane.poe@vizzuality.com","extraUserData":{"apps":[]},"createdAt":"2018-12-14T22:52:25.418Z","name":"jane","photo":"https://www.w3schools.com/howto/img_avatar.png"},{"provider":"local","role":"USER","_id":"5c069855ccc46a6660a4be68","email":"mark.twain@vizzuality.com","extraUserData":{"apps":[]},"createdAt":"2018-12-14T22:52:25.418Z","name":"mark","photo":"https://www.w3schools.com/howto/img_avatar.png"}]}'
     http_version:
   recorded_at: Tue, 08 Oct 2019 09:42:45 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/include_user_partial.yml
+++ b/spec/vcr_cassettes/include_user_partial.yml
@@ -28,7 +28,7 @@ http_interactions:
           - keep-alive
       body:
         encoding: UTF-8
-        string: '{"data": [{"_id": "57a1ff091ebc1ad91d089bdc","provider": "local","name": "John Doe","role": "ADMIN","email": "john.doe@vizzuality.com","createdAt": "2016-08-03T14:26:17.014Z","extraUserData": {"apps": ["rw","gfw","prep","aqueduct","forest-atlas","data4sdgs","aqueduct-water-risk"]}},{"provider": "local","email": "jane.poe@vizzuality.com","role": "USER","_id": "5c143429f8d19932db9d06ea","extraUserData": {"apps": []},"createdAt": "2018-12-14T22:52:25.418Z","photo": ""},{"provider": "local","name": "mark","role": "USER","_id": "5c069855ccc46a6660a4be68","extraUserData": {"apps": []},"createdAt": "2018-12-14T22:52:25.418Z","photo": ""}]}'
+        string: '{"data": [{"_id": "57a1ff091ebc1ad91d089bdc","provider": "local","name": "John Doe","role": "ADMIN","email": "john.doe@vizzuality.com","createdAt": "2016-08-03T14:26:17.014Z","extraUserData": {"apps": ["rw","gfw","prep","aqueduct","forest-atlas","data4sdgs","aqueduct-water-risk"]},"photo":"https://www.w3schools.com/howto/img_avatar.png"},{"provider": "local","email": "jane.poe@vizzuality.com","role": "USER","_id": "5c143429f8d19932db9d06ea","extraUserData": {"apps": []},"createdAt": "2018-12-14T22:52:25.418Z","photo":"https://www.w3schools.com/howto/img_avatar.png"},{"provider": "local","name": "mark","role": "USER","_id": "5c069855ccc46a6660a4be68","extraUserData": {"apps": []},"createdAt": "2018-12-14T22:52:25.418Z","photo":"https://www.w3schools.com/howto/img_avatar.png"}]}'
       http_version:
     recorded_at: Sat, 19 Oct 2019 05:35:17 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/n/projects/1883443/stories/170256234

## What does this PR fix?

When requesting dashboards/topics with `includes=user` option, the user photo is also returned.