### PR TITLE
Fix missing pagination metadata when including user information in dashboard endpoints

### DIFF
--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -9,15 +9,54 @@ class Api::DashboardsController < ApiController
   before_action :ensure_is_manager_or_admin, only: :update
   before_action :ensure_is_admin_for_highlighting, only: [:create, :update]
 
-  def handmade_pagination_links(collection)
-    prev_page = collection.current_page <= 1 ? 1 : collection.current_page - 1
-    next_page = collection.current_page >= collection.total_pages ? collection.total_pages : collection.current_page + 1
+  def get_self_link(collection, query)
+    self_query = query.clone
+    self_query = query.except(:page).clone
+    self_query['page[number]'] = collection.current_page
+    self_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{self_query.to_query}"
+  end
+
+  def get_prev_link(collection, query)
+    current = collection.current_page
+    prev_query = query.except(:page).clone
+    prev_query['page[number]'] = current <= 1 ? 1 : current - 1
+    prev_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{prev_query.to_query}"
+  end
+
+  def get_next_link(collection, query)
+    total = collection.total_pages
+    current = collection.current_page
+    next_query = query.except(:page).clone
+    next_query['page[number]'] = current >= total ? total : current + 1
+    next_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{next_query.to_query}"
+  end
+
+  def get_first_link(collection, query)
+    first_query = query.except(:page).clone
+    first_query['page[number]'] = 1
+    first_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{first_query.to_query}"
+  end
+
+  def get_last_link(collection, query)
+    last_query = query.except(:page).clone
+    last_query['page[number]'] = collection.total_pages
+    last_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{last_query.to_query}"
+  end
+
+  def handmade_pagination_links(collection, params)
+    query = params.except(:controller, :action, :format, :loggedUser, :user).clone.permit!
+    query['page[size]'] = collection.per_page unless query['page']&.has_key?('size')
     {
-      self: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=#{collection.current_page}&page[size]=#{collection.per_page}",
-      prev: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=#{prev_page}&page[size]=#{collection.per_page}",
-      next: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=#{next_page}&page[size]=#{collection.per_page}",
-      first: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=1&page[size]=#{collection.per_page}",
-      last: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=#{collection.total_pages}&page[size]=#{collection.per_page}",
+      self: get_self_link(collection, query),
+      prev: get_prev_link(collection, query),
+      next: get_next_link(collection, query),
+      first: get_first_link(collection, query),
+      last: get_last_link(collection, query),
     }
   end
 
@@ -56,7 +95,7 @@ class Api::DashboardsController < ApiController
       end
 
     render json: dashboards_json, meta: {
-      links: handmade_pagination_links(dashboards),
+      links: handmade_pagination_links(dashboards, params),
       'total-pages': dashboards.total_pages,
       'total-items': dashboards.total_entries,
       size: dashboards.per_page,

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -9,6 +9,18 @@ class Api::DashboardsController < ApiController
   before_action :ensure_is_manager_or_admin, only: :update
   before_action :ensure_is_admin_for_highlighting, only: [:create, :update]
 
+  def handmade_pagination_links(collection)
+    prev_page = collection.current_page <= 1 ? 1 : collection.current_page - 1
+    next_page = collection.current_page >= collection.total_pages ? collection.total_pages : collection.current_page + 1
+    {
+      self: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=#{collection.current_page}&page[size]=#{collection.per_page}",
+      prev: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=#{prev_page}&page[size]=#{collection.per_page}",
+      next: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=#{next_page}&page[size]=#{collection.per_page}",
+      first: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=1&page[size]=#{collection.per_page}",
+      last: "#{ENV['LOCAL_URL']}/v1/dashboard?page[number]=#{collection.total_pages}&page[size]=#{collection.per_page}",
+    }
+  end
+
   def index
     if params.include?('user.role') && @user&.dig('role').eql?('ADMIN')
       usersIdsByRole = UserService.usersByRole params['user.role']
@@ -42,7 +54,13 @@ class Api::DashboardsController < ApiController
       else
         dashboards
       end
-    render json: dashboards_json
+
+    render json: dashboards_json, meta: {
+      links: handmade_pagination_links(dashboards),
+      'total-pages': dashboards.total_pages,
+      'total-items': dashboards.total_entries,
+      size: dashboards.per_page,
+    }
   end
 
   def show

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -40,7 +40,6 @@ module PaginationHelper
 
   def self.handmade_pagination_links(collection, params)
     query = params.except(:controller, :action, :format, :loggedUser, :user).clone.permit!
-    query['page[size]'] = collection.per_page unless query['page']&.has_key?('size')
     {
       self: get_self_link(collection, query),
       prev: get_prev_link(collection, query),

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,52 @@
+module PaginationHelper
+  def self.get_self_link(collection, query)
+    self_query = query.clone
+    self_query = query.except(:page).clone
+    self_query['page[number]'] = collection.current_page
+    self_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{self_query.to_query}"
+  end
+
+  def self.get_prev_link(collection, query)
+    current = collection.current_page
+    prev_query = query.except(:page).clone
+    prev_query['page[number]'] = current <= 1 ? 1 : current - 1
+    prev_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{prev_query.to_query}"
+  end
+
+  def self.get_next_link(collection, query)
+    total = collection.total_pages
+    current = collection.current_page
+    next_query = query.except(:page).clone
+    next_query['page[number]'] = current >= total ? total : current + 1
+    next_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{next_query.to_query}"
+  end
+
+  def self.get_first_link(collection, query)
+    first_query = query.except(:page).clone
+    first_query['page[number]'] = 1
+    first_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{first_query.to_query}"
+  end
+
+  def self.get_last_link(collection, query)
+    last_query = query.except(:page).clone
+    last_query['page[number]'] = collection.total_pages
+    last_query['page[size]'] = collection.per_page
+    "#{ENV['LOCAL_URL']}/v1/dashboard?#{last_query.to_query}"
+  end
+
+  def self.handmade_pagination_links(collection, params)
+    query = params.except(:controller, :action, :format, :loggedUser, :user).clone.permit!
+    query['page[size]'] = collection.per_page unless query['page']&.has_key?('size')
+    {
+      self: get_self_link(collection, query),
+      prev: get_prev_link(collection, query),
+      next: get_next_link(collection, query),
+      first: get_first_link(collection, query),
+      last: get_last_link(collection, query),
+    }
+  end
+end

--- a/config/initializers/active_model_serializer.rb
+++ b/config/initializers/active_model_serializer.rb
@@ -13,6 +13,12 @@ class CustomPaginationLinks < ActiveModelSerializers::Adapter::JsonApi
       end
     end
 
+    # Links can be provided by the controller in the res[:meta][:links] property
+    # If that is the case, then res[:meta][:links] is deleted and its value replaces res[:links]
+    unless res[:meta].nil? || res[:meta][:links].nil?
+      res[:links] = res[:meta].delete(:links)
+    end
+
     return res
   end
 
@@ -29,7 +35,6 @@ class CustomPaginationLinks < ActiveModelSerializers::Adapter::JsonApi
   def normalize_pagination_links(links)
     links.each do |key, link|
       link = links[:self] if link.nil?
-
       links[key] = replace_dashboard_correct_url(replace_logged_user_query_param(link))
     end
   end

--- a/config/initializers/active_model_serializer.rb
+++ b/config/initializers/active_model_serializer.rb
@@ -4,6 +4,12 @@ class CustomPaginationLinks < ActiveModelSerializers::Adapter::JsonApi
   def success_document
     res = super
 
+    # Links can be provided by the controller in the res[:meta][:links] property
+    # If that is the case, then res[:meta][:links] is deleted and its value replaces res[:links]
+    unless res[:meta].nil? || res[:meta][:links].nil?
+      res[:links] = res[:meta].delete(:links)
+    end
+
     unless res[:links].nil?
       normalize_pagination_links(res[:links])
 
@@ -11,12 +17,6 @@ class CustomPaginationLinks < ActiveModelSerializers::Adapter::JsonApi
       if res[:meta].nil?
         res[:meta] = append_pagination_meta_info(@serializer.object)
       end
-    end
-
-    # Links can be provided by the controller in the res[:meta][:links] property
-    # If that is the case, then res[:meta][:links] is deleted and its value replaces res[:links]
-    unless res[:meta].nil? || res[:meta][:links].nil?
-      res[:links] = res[:meta].delete(:links)
     end
 
     return res

--- a/resourceWatchManager.sh
+++ b/resourceWatchManager.sh
@@ -9,19 +9,6 @@ case "$1" in
         type docker-compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
         docker-compose -f docker-compose-test.yml build && docker-compose -f docker-compose-test.yml up --abort-on-container-exit
         ;;
-    test-native)
-        export CC_TEST_REPORTER_ID=a
-        export CT_URL=http://localhost:9000
-        export CT_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
-        export API_VERSION=v1
-        export LOCAL_URL=http://localhost:4300
-        export RAILS_ENV=test
-        export SECRET_KEY_BASE=secret
-        export RW_API_URL=https://api.resourcewatch.org
-        export APIGATEWAY_URL=https://production-api.globalforestwatch.org
-        RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load
-        bundle exec rspec spec --fail-fast
-        ;;
     *)
         echo "Usage: resourceWatchManager.sh {develop|test}" >&2
         exit 1

--- a/resourceWatchManager.sh
+++ b/resourceWatchManager.sh
@@ -9,7 +9,20 @@ case "$1" in
         type docker-compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
         docker-compose -f docker-compose-test.yml build && docker-compose -f docker-compose-test.yml up --abort-on-container-exit
         ;;
-  *)
+    test-native)
+        export CC_TEST_REPORTER_ID=a
+        export CT_URL=http://localhost:9000
+        export CT_TOKEN=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
+        export API_VERSION=v1
+        export LOCAL_URL=http://localhost:4300
+        export RAILS_ENV=test
+        export SECRET_KEY_BASE=secret
+        export RW_API_URL=https://api.resourcewatch.org
+        export APIGATEWAY_URL=https://production-api.globalforestwatch.org
+        RAILS_ENV=test bundle exec rake db:drop db:create db:schema:load
+        bundle exec rspec spec --fail-fast
+        ;;
+    *)
         echo "Usage: resourceWatchManager.sh {develop|test}" >&2
         exit 1
         ;;

--- a/spec/controllers/api/dashboards_get_spec.rb
+++ b/spec/controllers/api/dashboards_get_spec.rb
@@ -586,5 +586,23 @@ describe Api::DashboardsController, type: :controller do
       expect_pagination_info(body[:links][:prev], "2", "5")
       expect_pagination_info(body[:links][:next], "4", "5")
     end
+
+    it 'when requesting user data for dashboards, includes meta objects with extra pagination info' do
+      get :index, params: {includes: 'user', page: {size: 5, number: 3}}
+
+      body = json_response
+      expect(body).to include(:meta)
+      expect(body[:meta]).to be_a(Object)
+      expect(body[:meta]['total-pages'.to_sym]).to be_a(Integer)
+      expect(body[:meta]['total-items'.to_sym]).to be_a(Integer)
+      expect(body[:meta][:size]).to be_a(Integer)
+
+      expect(body).to include(:links)
+      expect_pagination_info(body[:links][:self], "3", "5")
+      expect_pagination_info(body[:links][:first], "1", "5")
+      expect_pagination_info(body[:links][:last], "4", "5")
+      expect_pagination_info(body[:links][:prev], "2", "5")
+      expect_pagination_info(body[:links][:next], "4", "5")
+    end
   end
 end

--- a/spec/controllers/api/dashboards_get_spec.rb
+++ b/spec/controllers/api/dashboards_get_spec.rb
@@ -17,6 +17,13 @@ def expect_pagination_info(link, number, size)
   expect(linkQueryParams['page[size]'][0]).to eq(size)
 end
 
+def validate_pagination_link_query_params(link, params)
+  query_params = CGI.parse(URI.parse(link).query)
+  params.each do |key, value|
+    expect(query_params["#{key}"][0]).to eq(value)
+  end
+end
+
 describe Api::DashboardsController, type: :controller do
   describe 'GET #index' do
     before(:each) do
@@ -603,6 +610,42 @@ describe Api::DashboardsController, type: :controller do
       expect_pagination_info(body[:links][:last], "4", "5")
       expect_pagination_info(body[:links][:prev], "2", "5")
       expect_pagination_info(body[:links][:next], "4", "5")
+    end
+
+    it 'when requesting user data for dashboards, get params are kept in the pagination links returned' do
+      get :index, params: {includes: 'user', page: {size: 5, number: 3}}
+      body = json_response
+      expect(body).to include(:links)
+
+      validate_pagination_link_query_params(body[:links][:self], {
+        'page[number]': '3',
+        'page[size]': '5',
+        'includes': 'user',
+      })
+
+      validate_pagination_link_query_params(body[:links][:first], {
+        'page[number]': '1',
+        'page[size]': '5',
+        'includes': 'user',
+      })
+
+      validate_pagination_link_query_params(body[:links][:last], {
+        'page[number]': '4',
+        'page[size]': '5',
+        'includes': 'user',
+      })
+
+      validate_pagination_link_query_params(body[:links][:prev], {
+        'page[number]': '2',
+        'page[size]': '5',
+        'includes': 'user',
+      })
+
+      validate_pagination_link_query_params(body[:links][:next], {
+        'page[number]': '4',
+        'page[size]': '5',
+        'includes': 'user',
+      })
     end
   end
 end


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/n/projects/1883443/stories/169947430

## What does this PR fix?

When the query string param `includes=user` is used, no pagination metadata was returned. This PR adds the missing information.
