### PR TITLE
Add is-featured field to dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 18/12/2019
+- Add `is-featured` field to dashboards
+
 # 28/11/2019
 - Add `is-highlighted` field to dashboards
 

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -7,8 +7,7 @@ class Api::DashboardsController < ApiController
   before_action :get_user, only: %i[index]
   before_action :ensure_user_has_requested_apps, only: [:create, :update]
   before_action :ensure_is_manager_or_admin, only: :update
-  before_action :ensure_is_admin_for_highlighting, only: [:create, :update]
-  before_action :ensure_is_admin_for_featuring, only: [:create, :update]
+  before_action :ensure_is_admin_for_restricted_attrs, only: [:create, :update]
 
   def index
     if params.include?('user.role') && @user&.dig('role').eql?('ADMIN')
@@ -130,16 +129,12 @@ class Api::DashboardsController < ApiController
     render json: {errors: [{status: '403', title: 'You need to be either ADMIN or MANAGER and own the dashboard to update it'}]}, status: 403
   end
 
-  def ensure_is_admin_for_highlighting
-    return true unless request.params.dig('data', 'attributes', 'is-highlighted').present?
-    return true if request.params.dig('data', 'attributes', 'is-highlighted').present? and @user[:role].eql? "ADMIN"
-    render json: {errors: [{status: '403', title: 'You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard'}]}, status: 403
-  end
-
-  def ensure_is_admin_for_featuring
-    return true unless request.params.dig('data', 'attributes', 'is-featured').present?
-    return true if request.params.dig('data', 'attributes', 'is-featured').present? and @user[:role].eql? "ADMIN"
-    render json: {errors: [{status: '403', title: 'You need to be an ADMIN to create/update the is-featured attribute of the dashboard'}]}, status: 403
+  def ensure_is_admin_for_restricted_attrs
+    highlighted_present = request.params.dig('data', 'attributes', 'is-highlighted').present?
+    featured_present = request.params.dig('data', 'attributes', 'is-featured').present?
+    return true unless highlighted_present or featured_present
+    return true if (highlighted_present or featured_present) and @user[:role].eql? "ADMIN"
+    render json: {errors: [{status: '403', title: 'You need to be an ADMIN to create/update the provided attribute of the dashboard'}]}, status: 403
   end
 
   def get_user

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -23,6 +23,7 @@
 #  staging            :boolean          default(FALSE)
 #  application        :string           default(["\"rw\""]), not null, is an Array
 #  is_highlighted     :boolean          default(FALSE)
+#  is_featured        :boolean          default(FALSE)
 #
 
 class Dashboard < ApplicationRecord
@@ -42,6 +43,7 @@ class Dashboard < ApplicationRecord
 
   scope :by_application, ->(application) { where("?::varchar = ANY(application)", application) }
   scope :by_is_highlighted, ->(is_highlighted) { where(is_highlighted: is_highlighted) }
+  scope :by_is_featured, ->(is_featured) { where(is_featured: is_featured) }
   scope :by_published, ->(published) { where(published: published) }
   scope :by_private, ->(is_private) { where(private: is_private) }
   scope :by_user, ->(user) { where(user_id: user) }
@@ -62,6 +64,7 @@ class Dashboard < ApplicationRecord
 
     dashboards = dashboards.by_application(options[:application]) if options[:application]
     dashboards = dashboards.by_is_highlighted(options['is-highlighted'.to_sym]) if options['is-highlighted'.to_sym]
+    dashboards = dashboards.by_is_featured(options['is-featured'.to_sym]) if options['is-featured'.to_sym]
     dashboards = dashboards.by_published(options[:published]) if options[:published]
     dashboards = dashboards.by_private(options[:private]) if options[:private]
     dashboards = dashboards.by_user(options[:user]) if options[:user]

--- a/app/serializers/dashboard_serializer.rb
+++ b/app/serializers/dashboard_serializer.rb
@@ -23,13 +23,14 @@
 #  staging            :boolean          default(FALSE)
 #  application        :string           default(["\"rw\""]), not null, is an Array
 #  is_highlighted     :boolean          default(FALSE)
+#  is_featured        :boolean          default(FALSE)
 #
 
 class DashboardSerializer < ActiveModel::Serializer
   attributes :id, :name, :slug, :summary, :description,
              :content, :published, :photo, :user_id, :private,
              :production, :preproduction, :staging, :user, :application,
-             :is_highlighted
+             :is_highlighted, :is_featured
 
   def photo
     {

--- a/db/migrate/20191218122116_add_is_featured_field_to_dashboards.rb
+++ b/db/migrate/20191218122116_add_is_featured_field_to_dashboards.rb
@@ -1,0 +1,5 @@
+class AddIsFeaturedFieldToDashboards < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dashboards, :is_featured, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191128104945) do
+ActiveRecord::Schema.define(version: 20191218122116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 20191128104945) do
     t.boolean "staging", default: false
     t.string "application", default: ["rw"], null: false, array: true
     t.boolean "is_highlighted", default: false
+    t.boolean "is_featured", default: false
   end
 
   create_table "faqs", force: :cascade do |t|

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -308,7 +308,7 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response[:errors][0]).to have_key(:title)
 
       expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
 
     end
 
@@ -344,7 +344,7 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response[:errors][0]).to have_key(:title)
 
       expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
     end
 
     it 'with role ADMIN should create the dashboard providing the is-featured attribute' do
@@ -410,7 +410,7 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response[:errors][0]).to have_key(:status)
       expect(json_response[:errors][0]).to have_key(:title)
       expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-featured attribute of the dashboard")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
 
     end
 
@@ -445,7 +445,7 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response[:errors][0]).to have_key(:status)
       expect(json_response[:errors][0]).to have_key(:title)
       expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-featured attribute of the dashboard")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
     end
   end
 end

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -346,5 +346,106 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response[:errors][0][:status]).to eq("403")
       expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard")
     end
+
+    it 'with role ADMIN should create the dashboard providing the is-featured attribute' do
+      post :create, params: {
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "name": "Cities",
+            "summary": "test dashboard one summary",
+            "description": "Dashboard that uses cities",
+            "content": "test dashboard one description",
+            "published": true,
+            "photo": {
+              "cover": "/photos/cover/missing.png",
+              "thumb": "/photos/thumb/missing.png",
+              "original": "/photos/original/missing.png"
+            },
+            "user-id": "57ac9f9e29309063404573a2",
+            "private": true,
+            "application": [
+              "rw"
+            ],
+            "is-featured": true
+          }
+        },
+        loggedUser: USERS[:ADMIN]
+      }
+
+      expect(response.status).to eq(201)
+      sampleDashboard = json_response[:data]
+      validate_dashboard_structure(sampleDashboard)
+      expect(sampleDashboard[:attributes]['is-featured'.to_sym]).to eq(true)
+    end
+
+    it 'with role MANAGER should not create the dashboard providing the is-featured attribute' do
+      post :create, params: {
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "name": "Cities",
+            "summary": "test dashboard one summary",
+            "description": "Dashboard that uses cities",
+            "content": "test dashboard one description",
+            "published": true,
+            "photo": {
+              "cover": "/photos/cover/missing.png",
+              "thumb": "/photos/thumb/missing.png",
+              "original": "/photos/original/missing.png"
+            },
+            "user-id": "57ac9f9e29309063404573a2",
+            "private": true,
+            "application": [
+              "rw"
+            ],
+            "is-featured": true
+          }
+        },
+        loggedUser: USERS[:MANAGER]
+      }
+
+      expect(response.status).to eq(403)
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-featured attribute of the dashboard")
+
+    end
+
+    it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
+      post :create, params: {
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "name": "Cities",
+            "summary": "test dashboard one summary",
+            "description": "Dashboard that uses cities",
+            "content": "test dashboard one description",
+            "published": true,
+            "photo": {
+              "cover": "/photos/cover/missing.png",
+              "thumb": "/photos/thumb/missing.png",
+              "original": "/photos/original/missing.png"
+            },
+            "user-id": "57ac9f9e29309063404573a2",
+            "private": true,
+            "application": [
+              "rw"
+            ],
+            "is-featured": true
+          }
+        },
+        loggedUser: USERS[:USER]
+      }
+
+      expect(response.status).to eq(403)
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-featured attribute of the dashboard")
+    end
   end
 end

--- a/spec/controllers/api/dashboards_get_spec.rb
+++ b/spec/controllers/api/dashboards_get_spec.rb
@@ -130,6 +130,26 @@ describe Api::DashboardsController, type: :controller do
       expect(data.map { |dashboard| dashboard[:attributes]['is-highlighted'.to_sym] }.uniq).to eq([false])
     end
 
+    it 'with is-featured=true filter should return only featured dashboards' do
+      get :index, params: {'is-featured': true}
+
+      data = json_response[:data]
+
+      expect(response.status).to eq(200)
+      expect(data.size).to eq(1)
+      expect(data.map { |dashboard| dashboard[:attributes]['is-featured'.to_sym] }.uniq).to eq([true])
+    end
+
+    it 'with is-featured=false filter should return only non-featured dashboards' do
+      get :index, params: {'is-featured': false}
+
+      data = json_response[:data]
+
+      expect(response.status).to eq(200)
+      expect(data.size).to eq(4)
+      expect(data.map { |dashboard| dashboard[:attributes]['is-featured'.to_sym] }.uniq).to eq([false])
+    end
+
     it 'with includes=user while not being logged in should return dashboards including user name and email address' do
       VCR.use_cassette("include_user") do
         get :index, params: {includes: 'user'}

--- a/spec/controllers/api/dashboards_update_spec.rb
+++ b/spec/controllers/api/dashboards_update_spec.rb
@@ -260,7 +260,7 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes]['is-highlighted'.to_sym]).to eq(true)
     end
 
-    it 'with role MANAGER should not create the dashboard providing the is-highlighted attribute' do
+    it 'with role MANAGER should not update the dashboard providing the is-highlighted attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
         "data": {
@@ -273,16 +273,14 @@ describe Api::DashboardsController, type: :controller do
       }
 
       expect(response.status).to eq(403)
-
       expect(json_response).to have_key(:errors)
       expect(json_response[:errors][0]).to have_key(:status)
       expect(json_response[:errors][0]).to have_key(:title)
-
       expect(json_response[:errors][0][:status]).to eq("403")
       expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard")
     end
 
-    it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
+    it 'with role USER should not update the dashboard providing the is-highlighted attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
         "data": {
@@ -295,11 +293,67 @@ describe Api::DashboardsController, type: :controller do
       }
 
       expect(response.status).to eq(403)
-
       expect(json_response).to have_key(:errors)
       expect(json_response[:errors][0]).to have_key(:status)
       expect(json_response[:errors][0]).to have_key(:title)
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be either ADMIN or MANAGER and own the dashboard to update it")
+    end
 
+    it 'with role ADMIN should update the dashboard providing the is-featured attribute' do
+      patch :update, params: {
+        id: @dashboard_private_manager[:id],
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "is-featured": true
+          }
+        },
+        loggedUser: USERS[:ADMIN]
+      }
+
+      expect(response.status).to eq(200)
+      sampleDashboard = json_response[:data]
+      validate_dashboard_structure(sampleDashboard)
+      expect(sampleDashboard[:attributes]['is-featured'.to_sym]).to eq(true)
+    end
+
+    it 'with role MANAGER should not update the dashboard providing the is-featured attribute' do
+      patch :update, params: {
+        id: @dashboard_private_manager[:id],
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "is-featured": true
+          }
+        },
+        loggedUser: USERS[:MANAGER]
+      }
+
+      expect(response.status).to eq(403)
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-featured attribute of the dashboard")
+    end
+
+    it 'with role USER should not update the dashboard providing the is-featured attribute' do
+      patch :update, params: {
+        id: @dashboard_private_manager[:id],
+        "data": {
+          "type": "dashboards",
+          "attributes": {
+            "is-featured": true
+          }
+        },
+        loggedUser: USERS[:USER]
+      }
+
+      expect(response.status).to eq(403)
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
       expect(json_response[:errors][0][:status]).to eq("403")
       expect(json_response[:errors][0][:title]).to eq("You need to be either ADMIN or MANAGER and own the dashboard to update it")
     end

--- a/spec/controllers/api/dashboards_update_spec.rb
+++ b/spec/controllers/api/dashboards_update_spec.rb
@@ -277,7 +277,7 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response[:errors][0]).to have_key(:status)
       expect(json_response[:errors][0]).to have_key(:title)
       expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-highlighted attribute of the dashboard")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
     end
 
     it 'with role USER should not update the dashboard providing the is-highlighted attribute' do
@@ -335,7 +335,7 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response[:errors][0]).to have_key(:status)
       expect(json_response[:errors][0]).to have_key(:title)
       expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the is-featured attribute of the dashboard")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
     end
 
     it 'with role USER should not update the dashboard providing the is-featured attribute' do

--- a/spec/factories/dashboards.rb
+++ b/spec/factories/dashboards.rb
@@ -23,6 +23,7 @@
 #  staging            :boolean          default(FALSE)
 #  application        :string           default(["\"rw\""]), not null, is an Array
 #  is_highlighted     :boolean          default(FALSE)
+#  is_featured        :boolean          default(FALSE)
 #
 
 FactoryBot.define do
@@ -32,6 +33,7 @@ FactoryBot.define do
     user_id { '1a10d7c6e0a37126611fd7a6' }
     application { ['rw'] }
     is_highlighted { false }
+    is_featured { true }
     private { true }
   end
 
@@ -41,6 +43,7 @@ FactoryBot.define do
     user_id { '57a1ff091ebc1ad91d089bdc' }
     application { ['rw'] }
     is_highlighted { true }
+    is_featured { true }
     private { true }
   end
 
@@ -50,6 +53,7 @@ FactoryBot.define do
     user_id { '5c143429f8d19932db9d06ea' }
     application { ['rw'] }
     is_highlighted { false }
+    is_featured { false }
     private { true }
   end
 
@@ -59,6 +63,7 @@ FactoryBot.define do
     user_id { '57a1ff091ebc1ad91d089bdc' }
     application { %w(rw gfw) }
     is_highlighted { false }
+    is_featured { false }
     private { false }
   end
 
@@ -68,6 +73,7 @@ FactoryBot.define do
     user_id { '5c143429f8d19932db9d06ea' }
     application { ['gfw'] }
     is_highlighted { false }
+    is_featured { false }
     private { false }
   end
 
@@ -77,6 +83,7 @@ FactoryBot.define do
     user_id { '5c069855ccc46a6660a4be68' }
     application { ['gfw'] }
     is_highlighted { false }
+    is_featured { false }
     private { false }
   end
 
@@ -86,6 +93,7 @@ FactoryBot.define do
     user_id { '5c143429f8d19932db9d06ea' }
     private { false }
     is_highlighted { false }
+    is_featured { false }
     content { "[{\"id\":1520242542490,\"type\":\"text\",\"content\":\"\\u003cp\\u003eBiodiversity intro\\u003c/p\\u003e\"},{\"id\":1518109294215,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109371974,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109389591,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109424849,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}}]" }
   end
 end

--- a/spec/support/dashboard_helpers.rb
+++ b/spec/support/dashboard_helpers.rb
@@ -20,4 +20,5 @@ def validate_dashboard_structure(expected)
   expect(expected[:attributes]).to have_key(:user)
   expect(expected[:attributes]).to have_key(:application)
   expect(expected[:attributes]).to have_key('is-highlighted'.to_sym)
+  expect(expected[:attributes]).to have_key('is-featured'.to_sym)
 end


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/170311586

## What does this PR add?

This PR adds the `is_featured` attribute to dashboards. This is a boolean field that can only be edited by ADMIN users.