### PR TITLE
Fix problem with token parsing in delete requests

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -9,13 +9,7 @@ class ApiController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   def load_user_from_request
-    @user = {}
-
-    if request.params[:loggedUser].present? and request.params[:loggedUser].is_a? String
-      @user = JSON.parse(request.params[:loggedUser]) || {}
-    else
-      @user = request.params[:loggedUser] || {}
-    end
+    @user = get_user_from_request(request)
 
     has_valid_role = (@user.empty? or %w(ADMIN MANAGER USER).include? @user['role'])
     if (!has_valid_role)
@@ -66,5 +60,13 @@ class ApiController < ActionController::API
   def render_error(resource, status)
     render json: resource, status: status, adapter: :json_api,
            serializer: ActiveModel::Serializer::ErrorSerializer
+  end
+
+  def get_user_from_request(request)
+    if request.params[:loggedUser].present? and request.params[:loggedUser].is_a? String
+      JSON.parse(request.params[:loggedUser]) || {}
+    else
+      request.params[:loggedUser] || {}
+    end
   end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -10,11 +10,10 @@ class ApiController < ActionController::API
 
   def load_user_from_request
     @user = {}
-    if request.get? && request.params[:loggedUser].present?
-      @user = JSON.parse(request.params[:loggedUser]) || {}
-    end
 
-    if request.post? or request.patch? or request.delete? or request.put?
+    if request.params[:loggedUser].present? and request.params[:loggedUser].is_a? String
+      @user = JSON.parse(request.params[:loggedUser]) || {}
+    else
       @user = request.params[:loggedUser] || {}
     end
 

--- a/spec/controllers/api/dashboards_delete_spec.rb
+++ b/spec/controllers/api/dashboards_delete_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'constants'
+
+describe Api::DashboardsController, type: :controller do
+  describe 'DELETE #dashboard' do
+    before(:each) do
+      @dashboard_private_manager = FactoryBot.create :dashboard_private_manager
+    end
+
+    it 'with no user details should produce a 401 error' do
+      delete :destroy, params: {
+        id: @dashboard_private_manager[:id]
+      }
+
+      expect(response.status).to eq(401)
+      expect(response.body).to include "Unauthorized"
+    end
+
+    it 'with ADMIN token should delete the dashboard and return 204 No Content' do
+      delete :destroy, params: {
+        id: @dashboard_private_manager[:id],
+        loggedUser: USERS[:ADMIN]
+      }
+
+      expect(response.status).to eq(204)
+    end
+  end
+end

--- a/spec/controllers/api/topics_delete_spec.rb
+++ b/spec/controllers/api/topics_delete_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'constants'
+
+describe Api::TopicsController, type: :controller do
+  describe 'DELETE #topics' do
+    before(:each) do
+      @topic_private_manager = FactoryBot.create :topic_private_manager
+    end
+
+    it 'with no user details should produce a 401 error' do
+      delete :destroy, params: {
+        id: @topic_private_manager[:id]
+      }
+
+      expect(response.status).to eq(401)
+      expect(response.body).to include "Unauthorized"
+    end
+
+    it 'with ADMIN token should delete the topic and return 204 No Content' do
+      delete :destroy, params: {
+        id: @topic_private_manager[:id],
+        loggedUser: USERS[:ADMIN]
+      }
+
+      expect(response.status).to eq(204)
+    end
+  end
+end


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/170364508

## What does this PR fix?

It was detected that the DELETE endpoints of multiple entities in the RW Manager were not working (returning 401 Unauthorized despite providing ADMIN token).

The problem was caused by incorrect parsing of the `loggedUser` query param in DELETE requests. 

This PR changes the way the `loggedUser` query param is being parsed. 