### PR TITLE
Add permission check when deleting a dashboard

### DIFF
--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -2,7 +2,7 @@
 
 class Api::DashboardsController < ApiController
   before_action :set_dashboard, only: %i[show update destroy clone]
-  before_action :ensure_is_admin_or_owner_manager, only: :update
+  before_action :ensure_is_admin_or_owner_manager, only: [:update, :destroy]
 
   before_action :get_user, only: %i[index]
   before_action :ensure_user_has_requested_apps, only: [:create, :update]
@@ -121,12 +121,9 @@ class Api::DashboardsController < ApiController
 
   def ensure_is_admin_or_owner_manager
     return false if @user.nil?
-
     return true if @user[:role].eql? "ADMIN"
-
     return true if @user[:role].eql? "MANAGER" and @dashboard[:user_id].eql? @user[:id]
-
-    render json: {errors: [{status: '403', title: 'You need to be either ADMIN or MANAGER and own the dashboard to update it'}]}, status: 403
+    render json: {errors: [{status: '403', title: 'You need to be either ADMIN or MANAGER and own the dashboard to update/delete it'}]}, status: 403
   end
 
   def ensure_is_admin_for_restricted_attrs

--- a/spec/controllers/api/dashboards_delete_spec.rb
+++ b/spec/controllers/api/dashboards_delete_spec.rb
@@ -8,6 +8,7 @@ describe Api::DashboardsController, type: :controller do
   describe 'DELETE #dashboard' do
     before(:each) do
       @dashboard_private_manager = FactoryBot.create :dashboard_private_manager
+      @dashboard_private_user_1 = FactoryBot.create :dashboard_private_user_1
     end
 
     it 'with no user details should produce a 401 error' do
@@ -17,6 +18,35 @@ describe Api::DashboardsController, type: :controller do
 
       expect(response.status).to eq(401)
       expect(response.body).to include "Unauthorized"
+    end
+
+    it 'with role USER should produce an 403 error' do
+      delete :destroy, params: {
+        id: @dashboard_private_manager[:id],
+        loggedUser: USERS[:USER]
+      }
+
+      expect(response.status).to eq(403)
+      expect(response.body).to include "You need to be either ADMIN or MANAGER and own the dashboard to update/delete it"
+    end
+
+    it 'with role MANAGER but not the owner of the dashboard should produce an 403 error' do
+      delete :destroy, params: {
+        id: @dashboard_private_user_1[:id],
+        loggedUser: USERS[:MANAGER]
+      }
+
+      expect(response.status).to eq(403)
+      expect(response.body).to include "You need to be either ADMIN or MANAGER and own the dashboard to update/delete it"
+    end
+
+    it 'with role MANAGER and the owner of the dashboard should return 204 No Content' do
+      delete :destroy, params: {
+        id: @dashboard_private_manager[:id],
+        loggedUser: USERS[:MANAGER]
+      }
+
+      expect(response.status).to eq(204)
     end
 
     it 'with ADMIN token should delete the dashboard and return 204 No Content' do

--- a/spec/controllers/api/dashboards_delete_spec.rb
+++ b/spec/controllers/api/dashboards_delete_spec.rb
@@ -8,7 +8,6 @@ describe Api::DashboardsController, type: :controller do
   describe 'DELETE #dashboard' do
     before(:each) do
       @dashboard_private_manager = FactoryBot.create :dashboard_private_manager
-      @dashboard_private_user_1 = FactoryBot.create :dashboard_private_user_1
     end
 
     it 'with no user details should produce a 401 error' do
@@ -30,29 +29,66 @@ describe Api::DashboardsController, type: :controller do
       expect(response.body).to include "You need to be either ADMIN or MANAGER and own the dashboard to update/delete it"
     end
 
-    it 'with role MANAGER but not the owner of the dashboard should produce an 403 error' do
+    it 'with role MANAGER, NOT the owner of the dashboard, should produce an 403 error' do
+      spoofed_user = USERS[:MANAGER].deep_dup
+      spoofed_user[:id] = "123"
+
       delete :destroy, params: {
-        id: @dashboard_private_user_1[:id],
-        loggedUser: USERS[:MANAGER]
+        id: @dashboard_private_manager[:id],
+        loggedUser: spoofed_user
       }
 
       expect(response.status).to eq(403)
       expect(response.body).to include "You need to be either ADMIN or MANAGER and own the dashboard to update/delete it"
     end
 
-    it 'with role MANAGER and the owner of the dashboard should return 204 No Content' do
+    it 'with role MANAGER, owner of the dashboard, but non-matching applications between user and dashboard should produce an 403 error' do
+      spoofed_user = USERS[:MANAGER].deep_dup
+      spoofed_user[:extraUserData][:apps] = ["fake-app"]
+
       delete :destroy, params: {
         id: @dashboard_private_manager[:id],
-        loggedUser: USERS[:MANAGER]
+        loggedUser: spoofed_user
+      }
+
+      expect(response.status).to eq(403)
+      expect(response.body).to include "Your user account does not have permissions to delete this dashboard"
+    end
+
+    it 'with role MANAGER, owner of the dashboard, and at least one matching application between user and dashboard should return 204 No Content' do
+      spoofed_user = USERS[:MANAGER].deep_dup
+      spoofed_user[:extraUserData][:apps] = ["rw", "gfw"]
+
+      delete :destroy, params: {
+        id: @dashboard_private_manager[:id],
+        loggedUser: spoofed_user
       }
 
       expect(response.status).to eq(204)
     end
 
-    it 'with ADMIN token should delete the dashboard and return 204 No Content' do
+    it 'with role ADMIN, NOT owner of the dashboard, but non-matching applications between user and dashboard should produce an 403 error' do
+      spoofed_user = USERS[:ADMIN].deep_dup
+      spoofed_user[:id] = "123"
+      spoofed_user[:extraUserData][:apps] = ["fake-app"]
+
       delete :destroy, params: {
         id: @dashboard_private_manager[:id],
-        loggedUser: USERS[:ADMIN]
+        loggedUser: spoofed_user
+      }
+
+      expect(response.status).to eq(403)
+      expect(response.body).to include "Your user account does not have permissions to delete this dashboard"
+    end
+
+    it 'with role ADMIN, NOT owner of the dashboard, but at least one matching application between user and dashboard should return 204 No Content' do
+      spoofed_user = USERS[:ADMIN].deep_dup
+      spoofed_user[:id] = "123"
+      spoofed_user[:extraUserData][:apps] = ["rw", "gfw"]
+
+      delete :destroy, params: {
+        id: @dashboard_private_manager[:id],
+        loggedUser: spoofed_user
       }
 
       expect(response.status).to eq(204)

--- a/spec/controllers/api/dashboards_update_spec.rb
+++ b/spec/controllers/api/dashboards_update_spec.rb
@@ -297,7 +297,7 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response[:errors][0]).to have_key(:status)
       expect(json_response[:errors][0]).to have_key(:title)
       expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be either ADMIN or MANAGER and own the dashboard to update it")
+      expect(json_response[:errors][0][:title]).to eq("You need to be either ADMIN or MANAGER and own the dashboard to update/delete it")
     end
 
     it 'with role ADMIN should update the dashboard providing the is-featured attribute' do
@@ -355,7 +355,7 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response[:errors][0]).to have_key(:status)
       expect(json_response[:errors][0]).to have_key(:title)
       expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be either ADMIN or MANAGER and own the dashboard to update it")
+      expect(json_response[:errors][0][:title]).to eq("You need to be either ADMIN or MANAGER and own the dashboard to update/delete it")
     end
   end
 end


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/170050085

## What does this PR add?

Deleting dashboards was possible by any user. This PR adds the following permission checks for deleting a dashboard:
* Unauthenticated requests or `USER` result in permission error.
* `MANAGER` can only delete dashboards he/she owns AND if his/her applications match the dashboard applications.
* `ADMIN` can delete any dashboard as long as his/her applications match the dashboard applications.