### PR TITLE
Fix generated URL for pagination links (using API gateway URL instead of local URL)

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -4,7 +4,7 @@ module PaginationHelper
     self_query = query.except(:page).clone
     self_query['page[number]'] = collection.current_page
     self_query['page[size]'] = collection.per_page
-    "#{ENV['LOCAL_URL']}/v1/dashboard?#{self_query.to_query}"
+    "#{ENV['APIGATEWAY_URL']}/v1/dashboard?#{self_query.to_query}"
   end
 
   def self.get_prev_link(collection, query)
@@ -12,7 +12,7 @@ module PaginationHelper
     prev_query = query.except(:page).clone
     prev_query['page[number]'] = current <= 1 ? 1 : current - 1
     prev_query['page[size]'] = collection.per_page
-    "#{ENV['LOCAL_URL']}/v1/dashboard?#{prev_query.to_query}"
+    "#{ENV['APIGATEWAY_URL']}/v1/dashboard?#{prev_query.to_query}"
   end
 
   def self.get_next_link(collection, query)
@@ -21,21 +21,21 @@ module PaginationHelper
     next_query = query.except(:page).clone
     next_query['page[number]'] = current >= total ? total : current + 1
     next_query['page[size]'] = collection.per_page
-    "#{ENV['LOCAL_URL']}/v1/dashboard?#{next_query.to_query}"
+    "#{ENV['APIGATEWAY_URL']}/v1/dashboard?#{next_query.to_query}"
   end
 
   def self.get_first_link(collection, query)
     first_query = query.except(:page).clone
     first_query['page[number]'] = 1
     first_query['page[size]'] = collection.per_page
-    "#{ENV['LOCAL_URL']}/v1/dashboard?#{first_query.to_query}"
+    "#{ENV['APIGATEWAY_URL']}/v1/dashboard?#{first_query.to_query}"
   end
 
   def self.get_last_link(collection, query)
     last_query = query.except(:page).clone
     last_query['page[number]'] = collection.total_pages
     last_query['page[size]'] = collection.per_page
-    "#{ENV['LOCAL_URL']}/v1/dashboard?#{last_query.to_query}"
+    "#{ENV['APIGATEWAY_URL']}/v1/dashboard?#{last_query.to_query}"
   end
 
   def self.handmade_pagination_links(collection, params)


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/169947430

## What does this PR fix?

This PR fixes the URL of pagination links, using the APIGTEWAY_URL env variable instead of the LOCAL_URl variable.