### PR TITLE
Overriding data when cloning a dashboard

### DIFF
--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -89,7 +89,7 @@ class Api::DashboardsController < ApiController
 
   def clone
     begin
-      if duplicated_dashboard = @dashboard.duplicate(params.dig('loggedUser', 'id'))
+      if duplicated_dashboard = @dashboard.duplicate(params.dig('loggedUser', 'id'), dashboard_params_create.to_h)
         @dashboard = duplicated_dashboard
         render json: @dashboard, status: :ok
       else

--- a/app/controllers/concerns/duplicable.rb
+++ b/app/controllers/concerns/duplicable.rb
@@ -26,11 +26,12 @@ module Duplicable
     new_widgets_list
   end
 
-  def clone_model(widgets = [])
+  def clone_model(widgets = [], override = {})
     new_model = self.dup
     new_content = self.content
     widgets.each { |x| new_content.gsub!(x[:old_id], x[:new_id]) }
     new_model.content = new_content
+    new_model.attributes = new_model.attributes.merge(override)
     new_model.save
     new_model
   end

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -126,9 +126,9 @@ class Dashboard < ApplicationRecord
     update_column(:content, contents.to_json)
   end
 
-  def duplicate(user_id = nil)
+  def duplicate(user_id = nil, override = {})
     widgets = clone_widgets(user_id)
-    clone_model(widgets)
+    clone_model(widgets, override)
   end
 
   private

--- a/spec/controllers/api/dashboards_clone_spec.rb
+++ b/spec/controllers/api/dashboards_clone_spec.rb
@@ -7,13 +7,21 @@ require 'constants'
 describe Api::DashboardsController, type: :controller do
   describe 'POST #dashboard clone endpoint' do
     before(:each) do
-      FactoryBot.create :dashboard_with_widgets
+      @dashboard = FactoryBot.create :dashboard_with_widgets
     end
 
     it 'should perform the cloning' do
       VCR.use_cassette('dataset_widget') do
         post 'clone', params: {id: '1', loggedUser: USERS[:ADMIN]}
         expect(response.status).to eq(200)
+      end
+    end
+
+    it 'clones the dashboard changing the id of the user owner of the dashboard to the id of the user who requested the clone' do
+      VCR.use_cassette('dataset_widget') do
+        post 'clone', params: {id: @dashboard.id, loggedUser: USERS[:ADMIN]}
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)['data']['attributes']['user-id']).to eq(USERS[:ADMIN][:id])
       end
     end
   end

--- a/spec/controllers/api/dashboards_clone_spec.rb
+++ b/spec/controllers/api/dashboards_clone_spec.rb
@@ -17,9 +17,17 @@ describe Api::DashboardsController, type: :controller do
       end
     end
 
-    it 'clones the dashboard changing the id of the user owner of the dashboard to the id of the user who requested the clone' do
+    it 'clones the dashboard overriding data provided in the request body' do
       VCR.use_cassette('dataset_widget') do
-        post 'clone', params: {id: @dashboard.id, loggedUser: USERS[:ADMIN]}
+        post 'clone', params: {
+          id: @dashboard.id,
+          loggedUser: USERS[:ADMIN],
+          data: {
+            "attributes": {
+              "user-id": USERS[:ADMIN][:id]
+            }
+          },
+        }
         expect(response.status).to eq(200)
         expect(JSON.parse(response.body)['data']['attributes']['user-id']).to eq(USERS[:ADMIN][:id])
       end


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/170427595

## What does this PR add?

This PR adds the possibility of overriding data when cloning a dashboard. This way, the user ID of the new owner of the dashboard can be provided in the request body of the clone dashboard endpoint.