### PR TITLE
Fix bug detecting the role of the user when deleting a dashboard

### DIFF
--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -130,8 +130,8 @@ class Api::DashboardsController < ApiController
 
   def ensure_is_admin_or_owner_manager
     return false if @user.nil?
-    return true if @user[:role].eql? "ADMIN"
-    return true if @user[:role].eql? "MANAGER" and @dashboard[:user_id].eql? @user[:id]
+    return true if @user['role'].eql? "ADMIN"
+    return true if @user['role'].eql? "MANAGER" and @dashboard[:user_id].eql? @user[:id]
     render json: {errors: [{status: '403', title: 'You need to be either ADMIN or MANAGER and own the dashboard to update/delete it'}]}, status: 403
   end
 


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/170050085

## What does this PR fix?

There was a problem detecting the role of the current user when performing DELETE requests. For some reason, it works when accessing the user data with strings and not symbols, and the tests confirm that the rest of the features continue working.

This PR relates in specific to the comment made by Pablo here: https://www.pivotaltracker.com/story/show/170050085/comments/209978200