### PR TITLE
Add whitelist of fields for overriding dashboard data when cloning

### DIFF
--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -157,34 +157,26 @@ class Api::DashboardsController < ApiController
 
   def dashboard_params_get
     params.permit(:name, :published, :private, :user, :application, 'is-highlighted'.to_sym,
-                  'is-featured'.to_sym, user: [], :filter => [:published, :private, :user])
+      'is-featured'.to_sym, user: [], :filter => [:published, :private, :user])
   end
 
   def dashboard_params_create
-    new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-    new_params = ActionController::Parameters.new(new_params)
-    new_params.permit(:name, :description, :content, :published, :summary, :photo,
-                      :user_id, :private, :production, :preproduction, :staging,
-                      :is_highlighted, :is_featured, application:[])
+    ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :user_id, :private,
+      :production, :preproduction, :staging, :is_highlighted, :is_featured, application:[])
   rescue
     nil
   end
 
   def dashboard_params_update
-    new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-    new_params = ActionController::Parameters.new(new_params)
-    new_params.permit(:name, :description, :content, :published, :summary,
-                      :photo, :private, :production, :preproduction, :staging,
-                      :is_highlighted, :is_featured, application:[])
+    ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :private, :production,
+      :preproduction, :staging, :is_highlighted, :is_featured, application:[])
   rescue
     nil
   end
 
   def dashboard_params_clone
-    new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-    new_params = ActionController::Parameters.new(new_params)
-    new_params.permit(:name, :description, :content, :published, :summary, :photo,
-                      :user_id, :private, :production, :preproduction, :staging)
+    ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo,
+      :user_id, :private, :production, :preproduction, :staging)
   rescue
     nil
   end

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -90,7 +90,7 @@ class Api::DashboardsController < ApiController
 
   def clone
     begin
-      if duplicated_dashboard = @dashboard.duplicate(params.dig('loggedUser', 'id'), dashboard_params_create.to_h)
+      if duplicated_dashboard = @dashboard.duplicate(params.dig('loggedUser', 'id'), dashboard_params_clone.to_h)
         @dashboard = duplicated_dashboard
         render json: @dashboard, status: :ok
       else
@@ -176,6 +176,15 @@ class Api::DashboardsController < ApiController
     new_params.permit(:name, :description, :content, :published, :summary,
                       :photo, :private, :production, :preproduction, :staging,
                       :is_highlighted, :is_featured, application:[])
+  rescue
+    nil
+  end
+
+  def dashboard_params_clone
+    new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
+    new_params = ActionController::Parameters.new(new_params)
+    new_params.permit(:name, :description, :content, :published, :summary, :photo,
+                      :user_id, :private, :production, :preproduction, :staging)
   rescue
     nil
   end

--- a/app/controllers/api/faqs_controller.rb
+++ b/app/controllers/api/faqs_controller.rb
@@ -55,9 +55,7 @@ module Api
     end
 
     def faq_params
-      new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-      new_params = ActionController::Parameters.new(new_params)
-      new_params.permit(:question, :answer, :order)
+      ParamsHelper.permit(params, :question, :answer, :order)
     rescue
       nil
     end

--- a/app/controllers/api/partners_controller.rb
+++ b/app/controllers/api/partners_controller.rb
@@ -57,11 +57,9 @@ module Api
     end
 
     def partner_params
-      new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-      new_params = ActionController::Parameters.new(new_params)
-      new_params.permit(:name, :contact_email, :contact_name, :body, :partner_type, :summary,
-                        :logo, :white_logo, :icon, :cover, :published, :featured, :website, :partner_type,
-                        :production, :preproduction, :staging)
+      ParamsHelper.permit(params, :name, :contact_email, :contact_name, :body, :partner_type, :summary,
+        :logo, :white_logo, :icon, :cover, :published, :featured, :website, :partner_type,
+        :production, :preproduction, :staging)
     rescue
       nil
     end

--- a/app/controllers/api/profiles_controller.rb
+++ b/app/controllers/api/profiles_controller.rb
@@ -41,9 +41,7 @@ module Api
     end
 
     def profile_params
-      new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-      new_params = ActionController::Parameters.new(new_params)
-      new_params.permit(:user_id, :avatar)
+      ParamsHelper.permit(params, :user_id, :avatar)
     rescue
       nil
     end

--- a/app/controllers/api/static_pages_controller.rb
+++ b/app/controllers/api/static_pages_controller.rb
@@ -57,10 +57,7 @@ module Api
     end
 
     def static_page_params
-      new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-      new_params = ActionController::Parameters.new(new_params)
-      new_params.permit(:title, :summary, :description, :content, :photo, :published,
-                        :production, :preproduction, :staging)
+      ParamsHelper.permit(params, :title, :summary, :description, :content, :photo, :published, :production, :preproduction, :staging)
     rescue
       nil
     end

--- a/app/controllers/api/tools_controller.rb
+++ b/app/controllers/api/tools_controller.rb
@@ -57,10 +57,8 @@ module Api
     end
 
     def tool_params
-      new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-      new_params = ActionController::Parameters.new(new_params)
-      new_params.permit(:title, :slug, :summary, :description, :content,
-                        :thumbnail, :url, :published, :production, :preproduction, :staging)
+      ParamsHelper.permit(params, :title, :slug, :summary, :description, :content,
+        :thumbnail, :url, :published, :production, :preproduction, :staging)
     rescue
       nil
     end

--- a/app/controllers/api/topics_controller.rb
+++ b/app/controllers/api/topics_controller.rb
@@ -3,7 +3,7 @@
 class Api::TopicsController < ApiController
   before_action :set_topic, only: %i[show update destroy clone clone_dashboard]
   before_action :ensure_is_admin_or_owner_manager, only: :update
-  
+
   before_action :get_user, only: %i[index]
   before_action :ensure_user_has_requested_apps, only: [:create, :update]
   before_action :ensure_is_manager_or_admin, only: :update
@@ -114,17 +114,13 @@ class Api::TopicsController < ApiController
   end
 
   def topic_params_create
-    new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-    new_params = ActionController::Parameters.new(new_params)
-    new_params.permit(:name, :description, :content, :published, :summary, :photo, :user_id, :private, application:[])
+    ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :user_id, :private, application:[])
   rescue
     nil
   end
 
   def topic_params_update
-    new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
-    new_params = ActionController::Parameters.new(new_params)
-    new_params.permit(:name, :description, :content, :published, :summary, :photo, :private, application:[])
+    ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :private, application:[])
   rescue
     nil
   end

--- a/app/helpers/params_helper.rb
+++ b/app/helpers/params_helper.rb
@@ -1,0 +1,7 @@
+module ParamsHelper
+    def self.permit(params, *args)
+        new_params = ActiveModelSerializers::Deserialization.jsonapi_parse(params)
+        new_params = ActionController::Parameters.new(new_params)
+        new_params.permit(args)
+    end
+end

--- a/spec/controllers/api/dashboards_clone_spec.rb
+++ b/spec/controllers/api/dashboards_clone_spec.rb
@@ -10,26 +10,95 @@ describe Api::DashboardsController, type: :controller do
       @dashboard = FactoryBot.create :dashboard_with_widgets
     end
 
-    it 'should perform the cloning' do
+    it 'returns 200 OK with the created dashboard data when providing no data in request body (happy case)' do
       VCR.use_cassette('dataset_widget') do
-        post 'clone', params: {id: '1', loggedUser: USERS[:ADMIN]}
+        post 'clone', params: {id: @dashboard.id, loggedUser: USERS[:ADMIN]}
         expect(response.status).to eq(200)
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['data']['id']).to satisfy { |new_id| new_id != @dashboard['id'] }
+        expect(json_response['data']['attributes']['slug']).to satisfy { |new_slug| new_slug != @dashboard['slug'] }
+
+        expect(json_response['data']['attributes']['name']).to eq(@dashboard['name'])
+        expect(json_response['data']['attributes']['summary']).to eq(@dashboard['summary'])
+        expect(json_response['data']['attributes']['description']).to eq(@dashboard['description'])
+        expect(json_response['data']['attributes']['published']).to eq(@dashboard['published'])
+        expect(json_response['data']['attributes']['user-id']).to eq(@dashboard['user_id'])
+        expect(json_response['data']['attributes']['private']).to eq(@dashboard['private'])
+        expect(json_response['data']['attributes']['production']).to eq(@dashboard['production'])
+        expect(json_response['data']['attributes']['preproduction']).to eq(@dashboard['preproduction'])
+        expect(json_response['data']['attributes']['staging']).to eq(@dashboard['staging'])
+        expect(json_response['data']['attributes']['application']).to eq(@dashboard['application'])
+        expect(json_response['data']['attributes']['is-highlighted']).to eq(@dashboard['is_highlighted'])
+        expect(json_response['data']['attributes']['is-featured']).to eq(@dashboard['is_featured'])
       end
     end
 
-    it 'clones the dashboard overriding data provided in the request body' do
+    it 'returns 200 OK with the created dashboard data when providing valid data in request body (happy case)' do
       VCR.use_cassette('dataset_widget') do
+        new_data = {
+          name: 'Cloned dashboard',
+          summary: 'Cloned summary',
+          description: 'Cloned description',
+          published: false,
+          user_id: USERS[:ADMIN][:id],
+          private: false,
+          production: false,
+          preproduction: false,
+          staging: false,
+        }
+
         post 'clone', params: {
           id: @dashboard.id,
           loggedUser: USERS[:ADMIN],
-          data: {
-            "attributes": {
-              "user-id": USERS[:ADMIN][:id]
-            }
-          },
+          data: { attributes: new_data },
         }
+
         expect(response.status).to eq(200)
-        expect(JSON.parse(response.body)['data']['attributes']['user-id']).to eq(USERS[:ADMIN][:id])
+        json_response = JSON.parse(response.body)
+
+        expect(json_response['data']['id']).to satisfy { |new_id| new_id != @dashboard['id'] }
+        expect(json_response['data']['attributes']['slug']).to satisfy { |new_slug| new_slug != @dashboard['slug'] }
+
+        expect(json_response['data']['attributes']['application']).to eq(@dashboard['application'])
+        expect(json_response['data']['attributes']['is-highlighted']).to eq(@dashboard['is_highlighted'])
+        expect(json_response['data']['attributes']['is-featured']).to eq(@dashboard['is_featured'])
+
+        expect(json_response['data']['attributes']['name']).to eq(new_data[:name])
+        expect(json_response['data']['attributes']['summary']).to eq(new_data[:summary])
+        expect(json_response['data']['attributes']['description']).to eq(new_data[:description])
+        expect(json_response['data']['attributes']['published']).to eq(new_data[:published])
+        expect(json_response['data']['attributes']['user-id']).to eq(new_data[:user_id])
+        expect(json_response['data']['attributes']['private']).to eq(new_data[:private])
+        expect(json_response['data']['attributes']['production']).to eq(new_data[:production])
+        expect(json_response['data']['attributes']['preproduction']).to eq(new_data[:preproduction])
+        expect(json_response['data']['attributes']['staging']).to eq(new_data[:staging])
+      end
+    end
+
+    it 'returns 200 OK with valid cloned dashboard (with original values kept) when providing invalid override data in request body' do
+      VCR.use_cassette('dataset_widget') do
+        new_data = {
+          id: '999',
+          slug: 'slug',
+          is_highlighted: true,
+          is_featured: true,
+          application: ['fake-app'],
+        }
+
+        post 'clone', params: {
+          id: @dashboard.id,
+          loggedUser: USERS[:ADMIN],
+          data: { attributes: new_data },
+        }
+
+        expect(response.status).to eq(200)
+        json_response = JSON.parse(response.body)
+        expect(json_response['data']['id']).to satisfy { |new_id| new_id != @dashboard['id'] and new_id != new_data[:id] }
+        expect(json_response['data']['attributes']['slug']).to satisfy { |new_slug| new_slug != @dashboard['slug'] and new_slug != new_data[:slug] }
+        expect(json_response['data']['attributes']['application']).to eq(@dashboard['application'])
+        expect(json_response['data']['attributes']['is-highlighted']).to eq(@dashboard['is_highlighted'])
+        expect(json_response['data']['attributes']['is-featured']).to eq(@dashboard['is_featured'])
       end
     end
   end


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/170427595

## What does this PR add?

This PR adds a list of valid fields for overriding data when cloning a dashboard. Tests were also enforced to make sure this behaviour works as expected and original values are kept when trying to provide data that should not be overridden.

## What does this PR refactor?

This PR also refactored the existing test cases for cloning dashboards to tighten up some constrains when cloning dashboards, such as the id and slug being regenerated, and overridden data being actually used.

