### PR TITLE
Add sort by user fields for dashboard's GET endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 27/01/2020
+- Add possibility of sorting dashboards by user fields (such as name or role).
+
+# 18/12/2019
+- Add `is-featured` field to dashboards
+
 # v1.1.0
 
 ## 27/1/2020

--- a/db/migrate/20200106113315_add_user_name_and_role_to_dashboards.rb
+++ b/db/migrate/20200106113315_add_user_name_and_role_to_dashboards.rb
@@ -1,0 +1,6 @@
+class AddUserNameAndRoleToDashboards < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dashboards, :user_name, :string, default: nil
+    add_column :dashboards, :user_role, :string, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191218122116) do
+ActiveRecord::Schema.define(version: 20200106113315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,8 @@ ActiveRecord::Schema.define(version: 20191218122116) do
     t.string "application", default: ["rw"], null: false, array: true
     t.boolean "is_highlighted", default: false
     t.boolean "is_featured", default: false
+    t.string "user_name"
+    t.string "user_role"
   end
 
   create_table "faqs", force: :cascade do |t|

--- a/spec/controllers/api/dashboards_get_sort_user_fields_spec.rb
+++ b/spec/controllers/api/dashboards_get_sort_user_fields_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'constants'
+
+describe Api::DashboardsController, type: :controller do
+    describe 'GET #index sorted by user fields' do
+        before(:each) do
+            FactoryBot.create :dashboard_not_private_user_3
+            FactoryBot.create :dashboard_not_private_user_2
+            FactoryBot.create :dashboard_not_private_user_1
+        end
+        
+        it 'returns 403 Forbidden when trying to get dashboards sorted by user fields without authentication' do
+            get :index, params: { sort: "user.name" } 
+            expect(response.status).to eq(403)
+            expect(json_response).to have_key(:errors)
+            expect(json_response[:errors][0]).to have_key(:title)
+            expect(json_response[:errors][0][:title]).to eq("Sorting by user name or role not authorized.")
+        end
+        
+        it 'returns 403 Forbidden when trying to get dashboards sorted by user fields as user with role USER' do
+            get :index, params: {
+                includes: 'user',
+                sort: "user.name", 
+                loggedUser: JSON.generate(USERS[:USER])
+            }
+            expect(response.status).to eq(403)
+            expect(json_response).to have_key(:errors)
+            expect(json_response[:errors][0]).to have_key(:title)
+            expect(json_response[:errors][0][:title]).to eq("Sorting by user name or role not authorized.")
+        end
+        
+        it 'returns 403 Forbidden when trying to get dashboards sorted by user fields as user with role MANAGER' do
+            get :index, params: {
+                includes: 'user',
+                sort: "user.name", 
+                loggedUser: JSON.generate(USERS[:MANAGER])
+            }
+            expect(response.status).to eq(403)
+            expect(json_response).to have_key(:errors)
+            expect(json_response[:errors][0]).to have_key(:title)
+            expect(json_response[:errors][0][:title]).to eq("Sorting by user name or role not authorized.")
+        end
+        
+        it 'returns 200 OK when trying to get dashboards sorted by user name ASC as user with role ADMIN (happy case)' do
+            VCR.use_cassette("include_user", :allow_playback_repeats => true) do
+                get :index, params: {
+                    includes: 'user',
+                    sort: "user.name", 
+                    loggedUser: JSON.generate(USERS[:ADMIN])
+                }
+                data = json_response[:data]
+                expect(response.status).to eq(200)
+                expect(data.size).to eq(3)
+                expect(data.map { |dashboard| dashboard.dig(:attributes, :user, :name) }).to eq(['jane', 'mark', nil])
+            end
+        end
+
+        it 'returns 200 OK when trying to get dashboards sorted by user name DESC as user with role ADMIN (happy case)' do
+            VCR.use_cassette("include_user", :allow_playback_repeats => true) do
+                get :index, params: {
+                    includes: 'user',
+                    sort: "-user.name", 
+                    loggedUser: JSON.generate(USERS[:ADMIN])
+                }
+                data = json_response[:data]
+                expect(response.status).to eq(200)
+                expect(data.size).to eq(3)
+                expect(data.map { |dashboard| dashboard.dig(:attributes, :user, :name) }).to eq([nil, 'mark', 'jane'])
+            end
+        end
+
+        it 'returns 200 OK when trying to get dashboards sorted by user role ASC as user with role ADMIN (happy case)' do
+            VCR.use_cassette("include_user", :allow_playback_repeats => true) do
+                get :index, params: {
+                    includes: 'user',
+                    sort: "user.role", 
+                    loggedUser: JSON.generate(USERS[:ADMIN])
+                }
+                data = json_response[:data]
+                expect(response.status).to eq(200)
+                expect(data.size).to eq(3)
+                expect(data.map { |dashboard| dashboard.dig(:attributes, :user, :role) }).to eq(['ADMIN', 'USER', 'USER'])
+            end
+        end
+
+        it 'returns 200 OK when trying to get dashboards sorted by user role DESC as user with role ADMIN (happy case)' do
+            VCR.use_cassette("include_user", :allow_playback_repeats => true) do
+                get :index, params: {
+                    includes: 'user',
+                    sort: "-user.role", 
+                    loggedUser: JSON.generate(USERS[:ADMIN])
+                }
+                data = json_response[:data]
+                expect(response.status).to eq(200)
+                expect(data.size).to eq(3)
+                expect(data.map { |dashboard| dashboard.dig(:attributes, :user, :role) }).to eq(['USER', 'USER', 'ADMIN'])
+            end
+        end
+
+        it 'returns 200 OK with a correctly sorted list (case insensitive) when trying to get dashboards sorted by user name ASC as user with role ADMIN' do
+            VCR.use_cassette("include_fake_users_1", :allow_playback_repeats => true) do
+                get :index, params: {
+                    includes: 'user',
+                    sort: "user.name", 
+                    loggedUser: JSON.generate(USERS[:ADMIN])
+                }
+                data = json_response[:data]
+                expect(response.status).to eq(200)
+                expect(data.size).to eq(3)
+                expect(data.map { |dashboard| dashboard.dig(:attributes, :user, :name) }).to eq(['anthony', 'Bernard', 'carlos'])
+            end
+        end
+
+        it 'returns 200 OK with a deterministic list (sorted by id) when trying to get dashboards sorted by user name ASC as user with role ADMIN' do
+            VCR.use_cassette("include_fake_users_2", :allow_playback_repeats => true) do
+                get :index, params: {
+                    includes: 'user',
+                    sort: "user.name", 
+                    loggedUser: JSON.generate(USERS[:ADMIN])
+                }
+                data = json_response[:data]
+                expect(response.status).to eq(200)
+                expect(data.size).to eq(3)
+                expect(data.map { |dashboard| dashboard.dig(:attributes, :user, :name) }).to eq(['aaa', 'aaa', 'aaa'])
+                expect(data.map { |dashboard| dashboard.dig(:id) }).to eq(['42', '43', '44'])
+            end
+        end
+    end
+end
+                    

--- a/spec/controllers/api/dashboards_get_sort_user_fields_spec.rb
+++ b/spec/controllers/api/dashboards_get_sort_user_fields_spec.rb
@@ -7,9 +7,9 @@ require 'constants'
 describe Api::DashboardsController, type: :controller do
     describe 'GET #index sorted by user fields' do
         before(:each) do
-            FactoryBot.create :dashboard_not_private_user_3
-            FactoryBot.create :dashboard_not_private_user_2
-            FactoryBot.create :dashboard_not_private_user_1
+            @dashboard1 = FactoryBot.create :dashboard_not_private_user_3
+            @dashboard2 = FactoryBot.create :dashboard_not_private_user_2
+            @dashboard3 = FactoryBot.create :dashboard_not_private_user_1
         end
         
         it 'returns 403 Forbidden when trying to get dashboards sorted by user fields without authentication' do
@@ -116,6 +116,7 @@ describe Api::DashboardsController, type: :controller do
 
         it 'returns 200 OK with a deterministic list (sorted by id) when trying to get dashboards sorted by user name ASC as user with role ADMIN' do
             VCR.use_cassette("include_fake_users_2", :allow_playback_repeats => true) do
+                dashboard_ids = [@dashboard1.id.to_s, @dashboard2.id.to_s, @dashboard3.id.to_s].sort
                 get :index, params: {
                     includes: 'user',
                     sort: "user.name", 
@@ -125,7 +126,7 @@ describe Api::DashboardsController, type: :controller do
                 expect(response.status).to eq(200)
                 expect(data.size).to eq(3)
                 expect(data.map { |dashboard| dashboard.dig(:attributes, :user, :name) }).to eq(['aaa', 'aaa', 'aaa'])
-                expect(data.map { |dashboard| dashboard.dig(:id) }).to eq(['42', '43', '44'])
+                expect(data.map { |dashboard| dashboard.dig(:id) }).to eq(dashboard_ids)
             end
         end
     end

--- a/spec/vcr_cassettes/include_fake_users_1.yml
+++ b/spec/vcr_cassettes/include_fake_users_1.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:9000/auth/user/find-by-ids
+    body:
+      encoding: UTF-8
+      string: ids[]=57a1ff091ebc1ad91d089bdc&ids[]=5c143429f8d19932db9d06ea&ids[]=5c069855ccc46a6660a4be68
+    headers:
+      Authentication:
+      - eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Vary:
+      - Origin
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Response-Time:
+      - 6 ms
+      Content-Length:
+      - '459'
+      Date:
+      - Tue, 08 Oct 2019 09:42:45 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"provider":"local","role":"ADMIN","_id":"57a1ff091ebc1ad91d089bdc","name":"anthony","email":"john.doe@vizzuality.com","createdAt":"2016-08-03T14:26:17.014Z","extraUserData":{"apps":["rw","gfw","prep","aqueduct","forest-atlas","data4sdgs","aqueduct-water-risk"]},"photo":"https://www.w3schools.com/howto/img_avatar.png"},{"provider":"local","role":"USER","_id":"5c143429f8d19932db9d06ea","email":"jane.poe@vizzuality.com","extraUserData":{"apps":[]},"createdAt":"2018-12-14T22:52:25.418Z","name":"Bernard","photo":"https://www.w3schools.com/howto/img_avatar.png"},{"provider":"local","role":"USER","_id":"5c069855ccc46a6660a4be68","email":"mark.twain@vizzuality.com","extraUserData":{"apps":[]},"createdAt":"2018-12-14T22:52:25.418Z","name":"carlos","photo":"https://www.w3schools.com/howto/img_avatar.png"}]}'
+    http_version:
+  recorded_at: Tue, 08 Oct 2019 09:42:45 GMT
+recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/include_fake_users_2.yml
+++ b/spec/vcr_cassettes/include_fake_users_2.yml
@@ -1,0 +1,34 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:9000/auth/user/find-by-ids
+    body:
+      encoding: UTF-8
+      string: ids[]=57a1ff091ebc1ad91d089bdc&ids[]=5c143429f8d19932db9d06ea&ids[]=5c069855ccc46a6660a4be68
+    headers:
+      Authentication:
+      - eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Vary:
+      - Origin
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Response-Time:
+      - 6 ms
+      Content-Length:
+      - '459'
+      Date:
+      - Tue, 08 Oct 2019 09:42:45 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"data":[{"provider":"local","role":"ADMIN","_id":"57a1ff091ebc1ad91d089bdc","name":"aaa","email":"john.doe@vizzuality.com","createdAt":"2016-08-03T14:26:17.014Z","extraUserData":{"apps":["rw","gfw","prep","aqueduct","forest-atlas","data4sdgs","aqueduct-water-risk"]},"photo":"https://www.w3schools.com/howto/img_avatar.png"},{"provider":"local","role":"USER","_id":"5c143429f8d19932db9d06ea","email":"jane.poe@vizzuality.com","extraUserData":{"apps":[]},"createdAt":"2018-12-14T22:52:25.418Z","name":"aaa","photo":"https://www.w3schools.com/howto/img_avatar.png"},{"provider":"local","role":"USER","_id":"5c069855ccc46a6660a4be68","email":"mark.twain@vizzuality.com","extraUserData":{"apps":[]},"createdAt":"2018-12-14T22:52:25.418Z","name":"aaa","photo":"https://www.w3schools.com/howto/img_avatar.png"}]}'
+    http_version:
+  recorded_at: Tue, 08 Oct 2019 09:42:45 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/169174283

## What does this PR add?

This PR adds the possibility of sorting dashboards according to the role or name of the user to whom the dashboard belongs.

It should be noted that, in order to accomplish this, **all dashboards are updated with the current role and name of the user associated before sorting the collection**. This has an impact on the performance of the GET endpoint, but this impact is reduced when taking into account that this sort will be used in conjunction with `includes=user` option.