### PR TITLE
Setting the dashboard's user id on create/clone dashboards

### DIFF
--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -71,6 +71,7 @@ class Api::DashboardsController < ApiController
     end
 
     dashboard = Dashboard.new(dashboard_params_create)
+    dashboard.user_id = @user.dig('id')
     if dashboard.save
       dashboard.manage_content(request.base_url)
       render json: dashboard, status: :created
@@ -90,7 +91,9 @@ class Api::DashboardsController < ApiController
 
   def clone
     begin
-      if duplicated_dashboard = @dashboard.duplicate(params.dig('loggedUser', 'id'), dashboard_params_clone.to_h)
+      override = dashboard_params_clone.to_h
+      override[:user_id] = @user.dig('id')
+      if duplicated_dashboard = @dashboard.duplicate(params.dig('loggedUser', 'id'), override)
         @dashboard = duplicated_dashboard
         render json: @dashboard, status: :ok
       else
@@ -161,8 +164,8 @@ class Api::DashboardsController < ApiController
   end
 
   def dashboard_params_create
-    ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :user_id, :private,
-      :production, :preproduction, :staging, :is_highlighted, :is_featured, application:[])
+    ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :private, :production,
+      :preproduction, :staging, :is_highlighted, :is_featured, application:[])
   rescue
     nil
   end
@@ -175,8 +178,8 @@ class Api::DashboardsController < ApiController
   end
 
   def dashboard_params_clone
-    ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo,
-      :user_id, :private, :production, :preproduction, :staging)
+    ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :private, :production,
+      :preproduction, :staging)
   rescue
     nil
   end

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -11,6 +11,7 @@ class Api::DashboardsController < ApiController
   before_action :ensure_user_can_delete_dashboard, only: :destroy
   before_action :ensure_is_manager_or_admin, only: :update
   before_action :ensure_is_admin_for_restricted_attrs, only: [:create, :update]
+  before_action :ensure_user_has_at_least_rw_app, only: :create
 
   def index
     if params.include?('user.role') && @user&.dig('role').eql?('ADMIN')
@@ -66,10 +67,6 @@ class Api::DashboardsController < ApiController
   end
 
   def create
-    if request.params.dig('data', 'attributes', 'application').nil? and !@user.dig('extraUserData', 'apps').include? 'rw'
-      render json: {errors: [{status: '403', title: 'Your user account does not have permissions to use the default application(s)'}]}, status: 403 and return
-    end
-
     dashboard = Dashboard.new(dashboard_params_create)
     dashboard.user_id = @user.dig('id')
     if dashboard.save

--- a/app/controllers/api/topics_controller.rb
+++ b/app/controllers/api/topics_controller.rb
@@ -7,6 +7,7 @@ class Api::TopicsController < ApiController
   before_action :get_user, only: %i[index]
   before_action :ensure_user_has_requested_apps, only: [:create, :update]
   before_action :ensure_is_manager_or_admin, only: :update
+  before_action :ensure_user_has_at_least_rw_app, only: :create
 
   def index
     topics = Topic.fetch_all(topic_params_get)
@@ -33,10 +34,6 @@ class Api::TopicsController < ApiController
   end
 
   def create
-    if request.params.dig('data', 'attributes', 'application').nil? and !@user.dig('extraUserData', 'apps').include? 'rw'
-      render json: {errors: [{status: '403', title: 'Your user account does not have permissions to use the default application(s)'}]}, status: 403 and return
-    end
-
     topic = Topic.new(topic_params_create)
     if topic.save
       topic.manage_content(request.base_url)

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -51,6 +51,12 @@ class ApiController < ActionController::API
     end
   end
 
+  def ensure_user_has_at_least_rw_app
+    if request.params.dig('data', 'attributes', 'application').nil? and !@user.dig('extraUserData', 'apps').include? 'rw'
+      render json: {errors: [{status: '403', title: 'Your user account does not have permissions to use the default application(s)'}]}, status: 403 and return
+    end
+  end
+
   def record_not_found
     render json: {errors: [{status: '404', title: 'Record not found'}]}, status: 404
   end

--- a/spec/controllers/api/dashboards_clone_spec.rb
+++ b/spec/controllers/api/dashboards_clone_spec.rb
@@ -12,18 +12,18 @@ describe Api::DashboardsController, type: :controller do
 
     it 'returns 200 OK with the created dashboard data when providing no data in request body (happy case)' do
       VCR.use_cassette('dataset_widget') do
-        post 'clone', params: {id: @dashboard.id, loggedUser: USERS[:ADMIN]}
+        post 'clone', params: {id: @dashboard.id, loggedUser: USERS[:MANAGER]}
         expect(response.status).to eq(200)
         json_response = JSON.parse(response.body)
 
         expect(json_response['data']['id']).to satisfy { |new_id| new_id != @dashboard['id'] }
         expect(json_response['data']['attributes']['slug']).to satisfy { |new_slug| new_slug != @dashboard['slug'] }
+        expect(json_response['data']['attributes']['user-id']).to eq(USERS[:MANAGER][:id])
 
         expect(json_response['data']['attributes']['name']).to eq(@dashboard['name'])
         expect(json_response['data']['attributes']['summary']).to eq(@dashboard['summary'])
         expect(json_response['data']['attributes']['description']).to eq(@dashboard['description'])
         expect(json_response['data']['attributes']['published']).to eq(@dashboard['published'])
-        expect(json_response['data']['attributes']['user-id']).to eq(@dashboard['user_id'])
         expect(json_response['data']['attributes']['private']).to eq(@dashboard['private'])
         expect(json_response['data']['attributes']['production']).to eq(@dashboard['production'])
         expect(json_response['data']['attributes']['preproduction']).to eq(@dashboard['preproduction'])
@@ -41,7 +41,6 @@ describe Api::DashboardsController, type: :controller do
           summary: 'Cloned summary',
           description: 'Cloned description',
           published: false,
-          user_id: USERS[:ADMIN][:id],
           private: false,
           production: false,
           preproduction: false,
@@ -50,7 +49,7 @@ describe Api::DashboardsController, type: :controller do
 
         post 'clone', params: {
           id: @dashboard.id,
-          loggedUser: USERS[:ADMIN],
+          loggedUser: USERS[:MANAGER],
           data: { attributes: new_data },
         }
 
@@ -63,12 +62,12 @@ describe Api::DashboardsController, type: :controller do
         expect(json_response['data']['attributes']['application']).to eq(@dashboard['application'])
         expect(json_response['data']['attributes']['is-highlighted']).to eq(@dashboard['is_highlighted'])
         expect(json_response['data']['attributes']['is-featured']).to eq(@dashboard['is_featured'])
+        expect(json_response['data']['attributes']['user-id']).to eq(USERS[:MANAGER][:id])
 
         expect(json_response['data']['attributes']['name']).to eq(new_data[:name])
         expect(json_response['data']['attributes']['summary']).to eq(new_data[:summary])
         expect(json_response['data']['attributes']['description']).to eq(new_data[:description])
         expect(json_response['data']['attributes']['published']).to eq(new_data[:published])
-        expect(json_response['data']['attributes']['user-id']).to eq(new_data[:user_id])
         expect(json_response['data']['attributes']['private']).to eq(new_data[:private])
         expect(json_response['data']['attributes']['production']).to eq(new_data[:production])
         expect(json_response['data']['attributes']['preproduction']).to eq(new_data[:preproduction])
@@ -81,6 +80,7 @@ describe Api::DashboardsController, type: :controller do
         new_data = {
           id: '999',
           slug: 'slug',
+          user_id: '1',
           is_highlighted: true,
           is_featured: true,
           application: ['fake-app'],
@@ -88,7 +88,7 @@ describe Api::DashboardsController, type: :controller do
 
         post 'clone', params: {
           id: @dashboard.id,
-          loggedUser: USERS[:ADMIN],
+          loggedUser: USERS[:MANAGER],
           data: { attributes: new_data },
         }
 
@@ -96,6 +96,7 @@ describe Api::DashboardsController, type: :controller do
         json_response = JSON.parse(response.body)
         expect(json_response['data']['id']).to satisfy { |new_id| new_id != @dashboard['id'] and new_id != new_data[:id] }
         expect(json_response['data']['attributes']['slug']).to satisfy { |new_slug| new_slug != @dashboard['slug'] and new_slug != new_data[:slug] }
+        expect(json_response['data']['attributes']['user-id']).to eq(USERS[:MANAGER][:id])
         expect(json_response['data']['attributes']['application']).to eq(@dashboard['application'])
         expect(json_response['data']['attributes']['is-highlighted']).to eq(@dashboard['is_highlighted'])
         expect(json_response['data']['attributes']['is-featured']).to eq(@dashboard['is_featured'])

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -18,7 +18,6 @@ def get_new_dashboard_data(override = {})
         "thumb": "/photos/thumb/missing.png",
         "original": "/photos/original/missing.png"
       },
-      "user-id": "57ac9f9e29309063404573a2",
       "private": true,
       "production": true,
       "preproduction": false,
@@ -30,7 +29,7 @@ end
 describe Api::DashboardsController, type: :controller do
   describe 'POST #dashboard' do
     it 'with no user details should produce a 401 error' do
-      post :create, params: { 
+      post :create, params: {
         data: get_new_dashboard_data
       }
       expect(response.status).to eq(401)
@@ -46,8 +45,8 @@ describe Api::DashboardsController, type: :controller do
       sampleDashboard = json_response[:data]
       validate_dashboard_structure(sampleDashboard)
       expect(sampleDashboard[:attributes][:application]).to eq(['rw'])
+      expect(sampleDashboard[:attributes]["user-id".to_sym]).to eq(USERS[:USER][:id])
     end
-
 
     it 'with role USER that doesn\'t belong to rw and no explicit application should produce a 403 error' do
       spoofed_user = USERS[:USER].deep_dup
@@ -63,9 +62,9 @@ describe Api::DashboardsController, type: :controller do
 
     it 'with role USER and non-matching applications should produce an 403 error' do
       post :create, params: {
-        data: get_new_dashboard_data({ 
+        data: get_new_dashboard_data({
           attributes: {
-            application: ["fake-app"] 
+            application: ["fake-app"]
           }
         }),
         loggedUser: USERS[:USER]
@@ -84,11 +83,12 @@ describe Api::DashboardsController, type: :controller do
       sampleDashboard = json_response[:data]
       validate_dashboard_structure(sampleDashboard)
       expect(sampleDashboard[:attributes][:application]).to eq(['rw'])
+      expect(sampleDashboard[:attributes]["user-id".to_sym]).to eq(USERS[:MANAGER][:id])
     end
 
     it 'with multiple application values should create the dashboard with the multiple application values' do
       post :create, params: {
-        data: get_new_dashboard_data({ 
+        data: get_new_dashboard_data({
           attributes: {
             application: %w(rw gfw prep)
           }
@@ -100,11 +100,26 @@ describe Api::DashboardsController, type: :controller do
       sampleDashboard = json_response[:data]
       validate_dashboard_structure(sampleDashboard)
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
+      expect(sampleDashboard[:attributes]["user-id".to_sym]).to eq(USERS[:ADMIN][:id])
+    end
+
+    it 'returns 201 when providing a body containing a user_id and it matches the id of the user who created the dashboard' do
+      post :create, params: {
+        data: get_new_dashboard_data({
+          attributes: { user_id: "1" }
+        }),
+        loggedUser: USERS[:USER]
+      }
+
+      expect(response.status).to eq(201)
+      sampleDashboard = json_response[:data]
+      validate_dashboard_structure(sampleDashboard)
+      expect(sampleDashboard[:attributes]["user-id".to_sym]).to eq(USERS[:USER][:id])
     end
 
     it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
       post :create, params: {
-        data: get_new_dashboard_data({ 
+        data: get_new_dashboard_data({
           attributes: {
             "is-highlighted": true
           }
@@ -122,7 +137,7 @@ describe Api::DashboardsController, type: :controller do
 
     it 'with role MANAGER should not create the dashboard providing the is-highlighted attribute' do
       post :create, params: {
-        data: get_new_dashboard_data({ 
+        data: get_new_dashboard_data({
           attributes: {
             "is-highlighted": true
           }
@@ -140,7 +155,7 @@ describe Api::DashboardsController, type: :controller do
 
     it 'with role ADMIN should create the dashboard providing the is-highlighted attribute' do
       post :create, params: {
-        data: get_new_dashboard_data({ 
+        data: get_new_dashboard_data({
           attributes: {
             "is-highlighted": true
           }
@@ -156,7 +171,7 @@ describe Api::DashboardsController, type: :controller do
 
     it 'with role USER should not create the dashboard providing the is-featured attribute' do
       post :create, params: {
-        data: get_new_dashboard_data({ 
+        data: get_new_dashboard_data({
           attributes: {
             "is-featured": true
           }
@@ -174,7 +189,7 @@ describe Api::DashboardsController, type: :controller do
 
     it 'with role MANAGER should not create the dashboard providing the is-featured attribute' do
       post :create, params: {
-        data: get_new_dashboard_data({ 
+        data: get_new_dashboard_data({
           attributes: {
             "is-featured": true
           }
@@ -192,7 +207,7 @@ describe Api::DashboardsController, type: :controller do
 
     it 'with role ADMIN should create the dashboard providing the is-featured attribute' do
       post :create, params: {
-        data: get_new_dashboard_data({ 
+        data: get_new_dashboard_data({
           attributes: {
             "is-featured": true
           }

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -4,72 +4,47 @@ require 'spec_helper'
 require 'json'
 require 'constants'
 
+def get_new_dashboard_data(override = {})
+  {
+    "type": "dashboards",
+    "attributes": {
+      "name": "Cities",
+      "summary": "test dashboard one summary",
+      "description": "Dashboard that uses cities",
+      "content": "test dashboard one description",
+      "published": true,
+      "photo": {
+        "cover": "/photos/cover/missing.png",
+        "thumb": "/photos/thumb/missing.png",
+        "original": "/photos/original/missing.png"
+      },
+      "user-id": "57ac9f9e29309063404573a2",
+      "private": true,
+      "production": true,
+      "preproduction": false,
+      "staging": false
+    }
+  }.deep_merge(override)
+end
+
 describe Api::DashboardsController, type: :controller do
   describe 'POST #dashboard' do
     it 'with no user details should produce a 401 error' do
-      post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": [
-              "rw"
-            ]
-          }
-        }
+      post :create, params: { 
+        data: get_new_dashboard_data
       }
-
       expect(response.status).to eq(401)
     end
 
     it 'with role USER should create the dashboard (happy case)' do
       post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": [
-              "rw"
-            ]
-          }
-        },
+        data: get_new_dashboard_data,
         loggedUser: USERS[:USER]
       }
 
       expect(response.status).to eq(201)
-
       sampleDashboard = json_response[:data]
-
       validate_dashboard_structure(sampleDashboard)
-
       expect(sampleDashboard[:attributes][:application]).to eq(['rw'])
     end
 
@@ -79,57 +54,20 @@ describe Api::DashboardsController, type: :controller do
       spoofed_user[:extraUserData][:apps] = ["fake-app"]
 
       post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-          }
-        },
+        data: get_new_dashboard_data,
         loggedUser: spoofed_user
       }
 
       expect(response.status).to eq(403)
     end
 
-    it 'with role USER an non-matching applications should produce an 403 error' do
+    it 'with role USER and non-matching applications should produce an 403 error' do
       post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": [
-              "fake-app"
-            ]
+        data: get_new_dashboard_data({ 
+          attributes: {
+            application: ["fake-app"] 
           }
-        },
+        }),
         loggedUser: USERS[:USER]
       }
 
@@ -138,135 +76,75 @@ describe Api::DashboardsController, type: :controller do
 
     it 'with role MANAGER should create the dashboard' do
       post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": [
-              "rw"
-            ]
-          }
-        },
+        "data": get_new_dashboard_data,
         loggedUser: USERS[:MANAGER]
       }
 
       expect(response.status).to eq(201)
-
       sampleDashboard = json_response[:data]
-
       validate_dashboard_structure(sampleDashboard)
-
       expect(sampleDashboard[:attributes][:application]).to eq(['rw'])
-    end
-
-    it 'without an application value should create the dashboard with the default application value' do
-      post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": %w(rw gfw prep)
-          }
-        },
-        loggedUser: USERS[:ADMIN]
-      }
-
-      expect(response.status).to eq(201)
-
-      sampleDashboard = json_response[:data]
-
-      validate_dashboard_structure(sampleDashboard)
-
-      expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
     end
 
     it 'with multiple application values should create the dashboard with the multiple application values' do
       post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": %w(rw gfw prep)
-
+        data: get_new_dashboard_data({ 
+          attributes: {
+            application: %w(rw gfw prep)
           }
-        },
+        }),
         loggedUser: USERS[:ADMIN]
       }
 
       expect(response.status).to eq(201)
-
       sampleDashboard = json_response[:data]
-
       validate_dashboard_structure(sampleDashboard)
-
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
+    end
+
+    it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
+      post :create, params: {
+        data: get_new_dashboard_data({ 
+          attributes: {
+            "is-highlighted": true
+          }
+        }),
+        loggedUser: USERS[:USER]
+      }
+
+      expect(response.status).to eq(403)
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
+    end
+
+    it 'with role MANAGER should not create the dashboard providing the is-highlighted attribute' do
+      post :create, params: {
+        data: get_new_dashboard_data({ 
+          attributes: {
+            "is-highlighted": true
+          }
+        }),
+        loggedUser: USERS[:MANAGER]
+      }
+
+      expect(response.status).to eq(403)
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
     end
 
     it 'with role ADMIN should create the dashboard providing the is-highlighted attribute' do
       post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "application": [
-              "rw"
-            ],
+        data: get_new_dashboard_data({ 
+          attributes: {
             "is-highlighted": true
           }
-        },
+        }),
         loggedUser: USERS[:ADMIN]
       }
 
@@ -276,65 +154,13 @@ describe Api::DashboardsController, type: :controller do
       expect(sampleDashboard[:attributes]['is-highlighted'.to_sym]).to eq(true)
     end
 
-    it 'with role MANAGER should not create the dashboard providing the is-highlighted attribute' do
+    it 'with role USER should not create the dashboard providing the is-featured attribute' do
       post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "application": [
-              "rw"
-            ],
-            "is-highlighted": true
+        data: get_new_dashboard_data({ 
+          attributes: {
+            "is-featured": true
           }
-        },
-        loggedUser: USERS[:MANAGER]
-      }
-
-      expect(response.status).to eq(403)
-      expect(json_response).to have_key(:errors)
-      expect(json_response[:errors][0]).to have_key(:status)
-      expect(json_response[:errors][0]).to have_key(:title)
-
-      expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
-
-    end
-
-    it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
-      post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "application": [
-              "rw"
-            ],
-            "is-highlighted": true
-          }
-        },
+        }),
         loggedUser: USERS[:USER]
       }
 
@@ -342,34 +168,35 @@ describe Api::DashboardsController, type: :controller do
       expect(json_response).to have_key(:errors)
       expect(json_response[:errors][0]).to have_key(:status)
       expect(json_response[:errors][0]).to have_key(:title)
+      expect(json_response[:errors][0][:status]).to eq("403")
+      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
+    end
 
+    it 'with role MANAGER should not create the dashboard providing the is-featured attribute' do
+      post :create, params: {
+        data: get_new_dashboard_data({ 
+          attributes: {
+            "is-featured": true
+          }
+        }),
+        loggedUser: USERS[:MANAGER]
+      }
+
+      expect(response.status).to eq(403)
+      expect(json_response).to have_key(:errors)
+      expect(json_response[:errors][0]).to have_key(:status)
+      expect(json_response[:errors][0]).to have_key(:title)
       expect(json_response[:errors][0][:status]).to eq("403")
       expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
     end
 
     it 'with role ADMIN should create the dashboard providing the is-featured attribute' do
       post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "application": [
-              "rw"
-            ],
+        data: get_new_dashboard_data({ 
+          attributes: {
             "is-featured": true
           }
-        },
+        }),
         loggedUser: USERS[:ADMIN]
       }
 
@@ -377,75 +204,6 @@ describe Api::DashboardsController, type: :controller do
       sampleDashboard = json_response[:data]
       validate_dashboard_structure(sampleDashboard)
       expect(sampleDashboard[:attributes]['is-featured'.to_sym]).to eq(true)
-    end
-
-    it 'with role MANAGER should not create the dashboard providing the is-featured attribute' do
-      post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "application": [
-              "rw"
-            ],
-            "is-featured": true
-          }
-        },
-        loggedUser: USERS[:MANAGER]
-      }
-
-      expect(response.status).to eq(403)
-      expect(json_response).to have_key(:errors)
-      expect(json_response[:errors][0]).to have_key(:status)
-      expect(json_response[:errors][0]).to have_key(:title)
-      expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
-
-    end
-
-    it 'with role USER should not create the dashboard providing the is-highlighted attribute' do
-      post :create, params: {
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "user-id": "57ac9f9e29309063404573a2",
-            "private": true,
-            "application": [
-              "rw"
-            ],
-            "is-featured": true
-          }
-        },
-        loggedUser: USERS[:USER]
-      }
-
-      expect(response.status).to eq(403)
-      expect(json_response).to have_key(:errors)
-      expect(json_response[:errors][0]).to have_key(:status)
-      expect(json_response[:errors][0]).to have_key(:title)
-      expect(json_response[:errors][0][:status]).to eq("403")
-      expect(json_response[:errors][0][:title]).to eq("You need to be an ADMIN to create/update the provided attribute of the dashboard")
     end
   end
 end


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/170504340

## What does this PR add?

This PR adds a feature to the create and clone dashboard endpoints which consists of automatically setting the dashboard's `user_id` field to the id of the user who requested the create/clone.

## What does this PR refactor?

This PR does a small refactor to the dashboard creation tests.