### PR TITLE
Fix problem cloning dashboards without widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 28/02/2020
+- Fix problem cloning dashboards without content.
+
 # 27/01/2020
 - Add possibility of sorting dashboards by user fields (such as name or role).
 

--- a/app/controllers/concerns/duplicable.rb
+++ b/app/controllers/concerns/duplicable.rb
@@ -13,6 +13,7 @@ module Duplicable
   end
 
   def obtain_widget_list(content)
+    return [] if content == nil
     widgets_list = content.scan(/widgetId":"([^"]*)","datasetId":"([^"]*)"/)
     widgets_list.map { |w| {widget_id: w.first, dataset_id: w.last} }.uniq
   end

--- a/spec/factories/dashboards.rb
+++ b/spec/factories/dashboards.rb
@@ -96,4 +96,14 @@ FactoryBot.define do
     is_featured { false }
     content { "[{\"id\":1520242542490,\"type\":\"text\",\"content\":\"\\u003cp\\u003eBiodiversity intro\\u003c/p\\u003e\"},{\"id\":1518109294215,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109371974,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109389591,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109424849,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}}]" }
   end
+
+  factory :dashboard_without_widgets, class: Dashboard do
+    name { FFaker::Name.name }
+    published { true }
+    user_id { '5c143429f8d19932db9d06ea' }
+    private { false }
+    is_highlighted { false }
+    is_featured { false }
+    content { nil }
+  end
 end


### PR DESCRIPTION
This PR fixes a 500 error thrown while cloning dashboards that have content = nil