### PR TITLE
Fix problem with images of cloned dashboards

### DIFF
--- a/app/controllers/concerns/duplicable.rb
+++ b/app/controllers/concerns/duplicable.rb
@@ -33,6 +33,7 @@ module Duplicable
     widgets.each { |x| new_content.gsub!(x[:old_id], x[:new_id]) }
     new_model.content = new_content
     new_model.attributes = new_model.attributes.merge(override)
+    new_model.image_base = self.photo
     new_model.save
     new_model
   end


### PR DESCRIPTION
This PR fixes the issue raised by [this PT task](https://www.pivotaltracker.com/story/show/171105405), in which images of cloned dashboards were not accessible.