### PR TITLE
Add new fields `author_title` and `author_image` on the dashboard model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 19/03/2020
+
+- Add new fields to the dashboard model for `author_title` and `author_image`.
+
 # v1.2.0
 
 ## 28/02/2020

--- a/app/controllers/api/dashboards_controller.rb
+++ b/app/controllers/api/dashboards_controller.rb
@@ -165,27 +165,27 @@ class Api::DashboardsController < ApiController
   end
 
   def dashboard_params_get
-    params.permit(:name, :published, :private, :user, :application, 'is-highlighted'.to_sym, :sort,
+    params.permit(:name, :published, :private, :user, :application, 'is-highlighted'.to_sym, :sort, 'author-title'.to_sym,
       'is-featured'.to_sym, user: [], :filter => [:published, :private, :user])
   end
 
   def dashboard_params_create
     ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :private, :production,
-      :preproduction, :staging, :is_highlighted, :is_featured, application:[])
+      :preproduction, :staging, :is_highlighted, :is_featured, :autor_title, :autor_image, application:[])
   rescue
     nil
   end
 
   def dashboard_params_update
     ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :private, :production,
-      :preproduction, :staging, :is_highlighted, :is_featured, application:[])
+      :preproduction, :staging, :is_highlighted, :is_featured, :autor_title, :autor_image, application:[])
   rescue
     nil
   end
 
   def dashboard_params_clone
     ParamsHelper.permit(params, :name, :description, :content, :published, :summary, :photo, :private, :production,
-      :preproduction, :staging)
+      :preproduction, :staging, :autor_title, :autor_image)
   rescue
     nil
   end

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -3,29 +3,34 @@
 #
 # Table name: dashboards
 #
-#  id                 :bigint(8)        not null, primary key
-#  name               :string
-#  slug               :string
-#  description        :string
-#  content            :text
-#  published          :boolean
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  summary            :string
-#  photo_file_name    :string
-#  photo_content_type :string
-#  photo_file_size    :integer
-#  photo_updated_at   :datetime
-#  user_id            :string
-#  user_name          :string
-#  user_role          :string
-#  private            :boolean          default(TRUE)
-#  production         :boolean          default(TRUE)
-#  preproduction      :boolean          default(FALSE)
-#  staging            :boolean          default(FALSE)
-#  application        :string           default(["\"rw\""]), not null, is an Array
-#  is_highlighted     :boolean          default(FALSE)
-#  is_featured        :boolean          default(FALSE)
+#  id                        :bigint(8)        not null, primary key
+#  name                      :string
+#  slug                      :string
+#  description               :string
+#  content                   :text
+#  published                 :boolean
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  summary                   :string
+#  photo_file_name           :string
+#  photo_content_type        :string
+#  photo_file_size           :integer
+#  photo_updated_at          :datetime
+#  user_id                   :string
+#  user_name                 :string
+#  user_role                 :string
+#  private                   :boolean          default(TRUE)
+#  production                :boolean          default(TRUE)
+#  preproduction             :boolean          default(FALSE)
+#  staging                   :boolean          default(FALSE)
+#  application               :string           default(["\"rw\""]), not null, is an Array
+#  is_highlighted            :boolean          default(FALSE)
+#  is_featured               :boolean          default(FALSE)
+#  author_title              :string           default('')
+#  author_image_file_name    :string
+#  author_image_content_type :string
+#  author_image_file_size    :integer
+#  author_image_updated_at   :datetime
 #
 
 class Dashboard < ApplicationRecord
@@ -43,6 +48,11 @@ class Dashboard < ApplicationRecord
   validates_attachment_content_type :photo, content_type: %r{^image\/.*}
   do_not_validate_attachment_file_type :photo
 
+  has_attached_file :author_image, styles: { cover: '1280x>', thumb: '110x>', medium: '500x' }
+  validates_attachment_content_type :author_image, content_type: %r{^image\/.*}
+  do_not_validate_attachment_file_type :author_image
+
+  scope :by_author_title, ->(author_title) { where("author_title ilike ?", "%#{author_title}%") }
   scope :by_application, ->(application) { where("?::varchar = ANY(application)", application) }
   scope :by_is_highlighted, ->(is_highlighted) { where(is_highlighted: is_highlighted) }
   scope :by_is_featured, ->(is_featured) { where(is_featured: is_featured) }
@@ -64,6 +74,7 @@ class Dashboard < ApplicationRecord
       dashboards = dashboards.by_user(options[:filter][:user]) if options[:filter][:user]
     end
 
+    dashboards = dashboards.by_author_title(options['author-title'.to_sym]) if options['author-title'.to_sym]
     dashboards = dashboards.by_application(options[:application]) if options[:application]
     dashboards = dashboards.by_is_highlighted(options['is-highlighted'.to_sym]) if options['is-highlighted'.to_sym]
     dashboards = dashboards.by_is_featured(options['is-featured'.to_sym]) if options['is-featured'.to_sym]

--- a/app/serializers/dashboard_serializer.rb
+++ b/app/serializers/dashboard_serializer.rb
@@ -3,40 +3,53 @@
 #
 # Table name: dashboards
 #
-#  id                 :bigint(8)        not null, primary key
-#  name               :string
-#  slug               :string
-#  description        :string
-#  content            :text
-#  published          :boolean
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  summary            :string
-#  photo_file_name    :string
-#  photo_content_type :string
-#  photo_file_size    :integer
-#  photo_updated_at   :datetime
-#  user_id            :string
-#  private            :boolean          default(TRUE)
-#  production         :boolean          default(TRUE)
-#  preproduction      :boolean          default(FALSE)
-#  staging            :boolean          default(FALSE)
-#  application        :string           default(["\"rw\""]), not null, is an Array
-#  is_highlighted     :boolean          default(FALSE)
-#  is_featured        :boolean          default(FALSE)
+#  id                        :bigint(8)        not null, primary key
+#  name                      :string
+#  slug                      :string
+#  description               :string
+#  content                   :text
+#  published                 :boolean
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  summary                   :string
+#  photo_file_name           :string
+#  photo_content_type        :string
+#  photo_file_size           :integer
+#  photo_updated_at          :datetime
+#  user_id                   :string
+#  private                   :boolean          default(TRUE)
+#  production                :boolean          default(TRUE)
+#  preproduction             :boolean          default(FALSE)
+#  staging                   :boolean          default(FALSE)
+#  application               :string           default(["\"rw\""]), not null, is an Array
+#  is_highlighted            :boolean          default(FALSE)
+#  is_featured               :boolean          default(FALSE)
+#  author_title              :string           default('')
+#  author_image_file_name    :string
+#  author_image_content_type :string
+#  author_image_file_size    :integer
+#  author_image_updated_at   :datetime
 #
 
 class DashboardSerializer < ActiveModel::Serializer
   attributes :id, :name, :slug, :summary, :description,
              :content, :published, :photo, :user_id, :private,
              :production, :preproduction, :staging, :user, :application,
-             :is_highlighted, :is_featured
+             :is_highlighted, :is_featured, :author_title, :author_image
 
   def photo
     {
       cover: object.photo.url(:cover),
       thumb: object.photo.url(:thumb),
       original: object.photo.url(:original)
+    }
+  end
+
+  def author_image
+    {
+      cover: object.author_image.url(:cover),
+      thumb: object.author_image.url(:thumb),
+      original: object.author_image.url(:original)
     }
   end
 

--- a/db/migrate/20200319105154_dashboard_author_fields.rb
+++ b/db/migrate/20200319105154_dashboard_author_fields.rb
@@ -1,0 +1,6 @@
+class DashboardAuthorFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :dashboards, :author_title, :string, default: ''
+    add_attachment :dashboards, :author_image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200106113315) do
+ActiveRecord::Schema.define(version: 20200319105154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,11 @@ ActiveRecord::Schema.define(version: 20200106113315) do
     t.boolean "is_featured", default: false
     t.string "user_name"
     t.string "user_role"
+    t.string "author_title", default: ""
+    t.string "author_image_file_name"
+    t.string "author_image_content_type"
+    t.integer "author_image_file_size"
+    t.datetime "author_image_updated_at"
   end
 
   create_table "faqs", force: :cascade do |t|

--- a/spec/controllers/api/dashboards_clone_spec.rb
+++ b/spec/controllers/api/dashboards_clone_spec.rb
@@ -31,6 +31,10 @@ def compare_cloned_with_existing(cloned_dash, initial_id, user_id, override_data
   expect(cloned_dash['attributes']['photo']['cover']).to eq(initial_dash[:attributes][:photo][:cover])
   expect(cloned_dash['attributes']['photo']['thumb']).to eq(initial_dash[:attributes][:photo][:thumb])
   expect(cloned_dash['attributes']['photo']['original']).to eq(initial_dash[:attributes][:photo][:original])
+  expect(cloned_dash['attributes']['author-title']).to eq(initial_dash[:attributes][:"author-title"])
+  expect(cloned_dash['attributes']['author-image']['cover']).to eq(initial_dash[:attributes][:"author-image"][:cover])
+  expect(cloned_dash['attributes']['author-image']['thumb']).to eq(initial_dash[:attributes][:"author-image"][:thumb])
+  expect(cloned_dash['attributes']['author-image']['original']).to eq(initial_dash[:attributes][:"author-image"][:original])
 end
 
 describe Api::DashboardsController, type: :controller do
@@ -60,6 +64,7 @@ describe Api::DashboardsController, type: :controller do
           production: false,
           preproduction: false,
           staging: false,
+          author_title: 'Example author title',
         }
 
         post 'clone', params: {

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -22,6 +22,7 @@ def get_new_dashboard_data(override = {})
       "production": true,
       "preproduction": false,
       "staging": false,
+      "application": ["rw"],
       "author_title": "Auhtor title",
       "author_image": {
         "cover": "/photos/cover/missing.png",

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -21,7 +21,13 @@ def get_new_dashboard_data(override = {})
       "private": true,
       "production": true,
       "preproduction": false,
-      "staging": false
+      "staging": false,
+      "author_title": "Auhtor title",
+      "author_image": {
+        "cover": "/photos/cover/missing.png",
+        "thumb": "/photos/thumb/missing.png",
+        "original": "/photos/original/missing.png"
+      },
     }
   }.deep_merge(override)
 end

--- a/spec/controllers/api/dashboards_create_spec.rb
+++ b/spec/controllers/api/dashboards_create_spec.rb
@@ -23,7 +23,7 @@ def get_new_dashboard_data(override = {})
       "preproduction": false,
       "staging": false,
       "application": ["rw"],
-      "author_title": "Auhtor title",
+      "author_title": "Author title",
       "author_image": {
         "cover": "/photos/cover/missing.png",
         "thumb": "/photos/thumb/missing.png",

--- a/spec/controllers/api/dashboards_get_spec.rb
+++ b/spec/controllers/api/dashboards_get_spec.rb
@@ -84,6 +84,37 @@ describe Api::DashboardsController, type: :controller do
       expect(data.map { |dashboard| dashboard[:attributes][:"name"] }.uniq).to eq([@dashboard_private_user_1.name])
     end
 
+    it 'with author-title=<string> filter should return only dashboards with "string" in the author title (full match)' do
+      get :index, params: { "author-title": @dashboard_private_user_1.author_title }
+
+      data = json_response[:data]
+
+      expect(response.status).to eq(200)
+      expect(data.size).to eq(1)
+
+      expect(data.map { |dashboard| dashboard[:attributes][:"author-title"] }.uniq).to eq([@dashboard_private_user_1.author_title])
+    end
+
+    it 'with author-title=<string> filter should return only dashboards with "string" in the author-title (partial match)' do
+      get :index, params: { "author-title": @dashboard_private_user_1.author_title.split()[1]}
+
+      data = json_response[:data]
+
+      expect(response.status).to eq(200)
+      expect(data.size).to be >= 1
+      expect(data.map { |dashboard| dashboard[:attributes][:"author-title"] }.uniq).to eq([@dashboard_private_user_1.author_title])
+    end
+
+    it 'with author-title=<string> filter should return dashboards with "string"/"String" in the author-title (case insensitivity)' do
+      get :index, params: { "author-title": @dashboard_private_user_1.author_title.downcase}
+
+      data = json_response[:data]
+
+      expect(response.status).to eq(200)
+      expect(data.size).to be >= 1
+      expect(data.map { |dashboard| dashboard[:attributes][:"author-title"] }.uniq).to eq([@dashboard_private_user_1.author_title])
+    end
+
     it 'with user=<userId> filter should return only dashboards associated with that user' do
       get :index, params: {user: '57a1ff091ebc1ad91d089bdc'}
 

--- a/spec/controllers/api/dashboards_update_spec.rb
+++ b/spec/controllers/api/dashboards_update_spec.rb
@@ -23,7 +23,7 @@ def get_edit_dashboard_data(override = {})
       "preproduction": false,
       "staging": false,
       "application": ["rw"],
-      "author_title": "Auhtor title",
+      "author_title": "Author title",
       "author_image": {
         "cover": "/photos/cover/missing.png",
         "thumb": "/photos/thumb/missing.png",

--- a/spec/controllers/api/dashboards_update_spec.rb
+++ b/spec/controllers/api/dashboards_update_spec.rb
@@ -4,6 +4,35 @@ require 'spec_helper'
 require 'json'
 require 'constants'
 
+def get_edit_dashboard_data(override = {})
+  {
+    "type": "dashboards",
+    "attributes": {
+      "name": "Cities",
+      "summary": "test dashboard one summary",
+      "description": "Dashboard that uses cities",
+      "content": "test dashboard one description",
+      "published": true,
+      "photo": {
+        "cover": "/photos/cover/missing.png",
+        "thumb": "/photos/thumb/missing.png",
+        "original": "/photos/original/missing.png"
+      },
+      "private": true,
+      "production": true,
+      "preproduction": false,
+      "staging": false,
+      "application": ["rw"],
+      "author_title": "Auhtor title",
+      "author_image": {
+        "cover": "/photos/cover/missing.png",
+        "thumb": "/photos/thumb/missing.png",
+        "original": "/photos/original/missing.png"
+      },
+    }
+  }.deep_merge(override)
+end
+
 describe Api::DashboardsController, type: :controller do
   describe 'PATCH #dashboard' do
     before(:each) do
@@ -13,28 +42,7 @@ describe Api::DashboardsController, type: :controller do
     it 'with no user details should produce a 401 error' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": [
-              "rw"
-            ]
-          }
-        }
+        data: get_edit_dashboard_data,
       }
 
       expect(response.status).to eq(401)
@@ -43,28 +51,11 @@ describe Api::DashboardsController, type: :controller do
     it 'with role USER should produce an 403 error' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": [
-              "fake-app"
-            ]
+        data: get_edit_dashboard_data({
+          attributes: {
+            application: ["fake-app"]
           }
-        },
+        }),
         loggedUser: USERS[:USER]
       }
 
@@ -74,28 +65,11 @@ describe Api::DashboardsController, type: :controller do
     it 'with role MANAGER and non-matching applications between request and dashboard should produce an 403 error' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": [
-              "fake-app"
-            ]
+        data: get_edit_dashboard_data({
+          attributes: {
+            application: ["fake-app"]
           }
-        },
+        }),
         loggedUser: USERS[:MANAGER]
       }
 
@@ -108,28 +82,7 @@ describe Api::DashboardsController, type: :controller do
 
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": [
-              "rw"
-            ]
-          }
-        },
+        data: get_edit_dashboard_data,
         loggedUser: spoofed_user
       }
 
@@ -142,26 +95,11 @@ describe Api::DashboardsController, type: :controller do
 
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": %w(rw gfw)
+        data: get_edit_dashboard_data({
+          attributes: {
+            application: %w(rw gfw)
           }
-        },
+        }),
         loggedUser: spoofed_user
       }
 
@@ -171,35 +109,17 @@ describe Api::DashboardsController, type: :controller do
     it 'that belongs to the user and with role MANAGER and at least one matching applications between user and dashboard should update the dashboard' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": %w(rw gfw)
+        data: get_edit_dashboard_data({
+          attributes: {
+            application: %w(rw gfw)
           }
-        },
+        }),
         loggedUser: USERS[:MANAGER]
       }
 
       expect(response.status).to eq(200)
-
       sampleDashboard = json_response[:data]
-
       validate_dashboard_structure(sampleDashboard)
-
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw))
     end
 
@@ -209,43 +129,24 @@ describe Api::DashboardsController, type: :controller do
 
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
-          "type": "dashboards",
-          "attributes": {
-            "name": "Cities",
-            "summary": "test dashboard one summary",
-            "description": "Dashboard that uses cities",
-            "content": "test dashboard one description",
-            "published": true,
-            "photo": {
-              "cover": "/photos/cover/missing.png",
-              "thumb": "/photos/thumb/missing.png",
-              "original": "/photos/original/missing.png"
-            },
-            "private": true,
-            "production": true,
-            "preproduction": false,
-            "staging": false,
-            "application": %w(rw gfw prep)
-
+        data: get_edit_dashboard_data({
+          attributes: {
+            application: %w(rw gfw prep)
           }
-        },
+        }),
         loggedUser: spoofed_user
       }
 
       expect(response.status).to eq(200)
-
       sampleDashboard = json_response[:data]
-
       validate_dashboard_structure(sampleDashboard)
-
       expect(sampleDashboard[:attributes][:application]).to eq(%w(rw gfw prep))
     end
 
     it 'with role ADMIN should update the dashboard providing the is-highlighted attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
+        data: {
           "type": "dashboards",
           "attributes": {
             "is-highlighted": true
@@ -263,7 +164,7 @@ describe Api::DashboardsController, type: :controller do
     it 'with role MANAGER should not update the dashboard providing the is-highlighted attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
+        data: {
           "type": "dashboards",
           "attributes": {
             "is-highlighted": true
@@ -283,7 +184,7 @@ describe Api::DashboardsController, type: :controller do
     it 'with role USER should not update the dashboard providing the is-highlighted attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
+        data: {
           "type": "dashboards",
           "attributes": {
             "is-highlighted": true
@@ -303,7 +204,7 @@ describe Api::DashboardsController, type: :controller do
     it 'with role ADMIN should update the dashboard providing the is-featured attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
+        data: {
           "type": "dashboards",
           "attributes": {
             "is-featured": true
@@ -321,7 +222,7 @@ describe Api::DashboardsController, type: :controller do
     it 'with role MANAGER should not update the dashboard providing the is-featured attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
+        data: {
           "type": "dashboards",
           "attributes": {
             "is-featured": true
@@ -341,7 +242,7 @@ describe Api::DashboardsController, type: :controller do
     it 'with role USER should not update the dashboard providing the is-featured attribute' do
       patch :update, params: {
         id: @dashboard_private_manager[:id],
-        "data": {
+        data: {
           "type": "dashboards",
           "attributes": {
             "is-featured": true

--- a/spec/factories/dashboards.rb
+++ b/spec/factories/dashboards.rb
@@ -35,6 +35,7 @@ FactoryBot.define do
     is_highlighted { false }
     is_featured { true }
     private { true }
+    author_title { FFaker::Name.name }
   end
 
   factory :dashboard_private_user_1, class: Dashboard do
@@ -45,6 +46,7 @@ FactoryBot.define do
     is_highlighted { true }
     is_featured { true }
     private { true }
+    author_title { FFaker::Name.name }
   end
 
   factory :dashboard_private_user_2, class: Dashboard do
@@ -55,6 +57,7 @@ FactoryBot.define do
     is_highlighted { false }
     is_featured { false }
     private { true }
+    author_title { FFaker::Name.name }
   end
 
   factory :dashboard_not_private_user_1, class: Dashboard do
@@ -65,6 +68,7 @@ FactoryBot.define do
     is_highlighted { false }
     is_featured { false }
     private { false }
+    author_title { FFaker::Name.name }
   end
 
   factory :dashboard_not_private_user_2, class: Dashboard do
@@ -75,6 +79,7 @@ FactoryBot.define do
     is_highlighted { false }
     is_featured { false }
     private { false }
+    author_title { FFaker::Name.name }
   end
 
   factory :dashboard_not_private_user_3, class: Dashboard do
@@ -85,6 +90,7 @@ FactoryBot.define do
     is_highlighted { false }
     is_featured { false }
     private { false }
+    author_title { FFaker::Name.name }
   end
 
   factory :dashboard_with_widgets, class: Dashboard do
@@ -95,6 +101,7 @@ FactoryBot.define do
     is_highlighted { false }
     is_featured { false }
     content { "[{\"id\":1520242542490,\"type\":\"text\",\"content\":\"\\u003cp\\u003eBiodiversity intro\\u003c/p\\u003e\"},{\"id\":1518109294215,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109371974,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109389591,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}},{\"id\":1518109424849,\"type\":\"widget\",\"content\":{\"widgetId\":\"841a6544-e8c9-411d-9987-83e81b58fd6f\",\"datasetId\":\"9aa17362-2a4f-4a4f-9e4e-97ebb60ce76b\",\"categories\":[]}}]" }
+    author_title { FFaker::Name.name }
   end
 
   factory :dashboard_without_widgets, class: Dashboard do
@@ -105,5 +112,6 @@ FactoryBot.define do
     is_highlighted { false }
     is_featured { false }
     content { nil }
+    author_title { FFaker::Name.name }
   end
 end

--- a/spec/support/dashboard_helpers.rb
+++ b/spec/support/dashboard_helpers.rb
@@ -21,4 +21,6 @@ def validate_dashboard_structure(expected)
   expect(expected[:attributes]).to have_key(:application)
   expect(expected[:attributes]).to have_key('is-highlighted'.to_sym)
   expect(expected[:attributes]).to have_key('is-featured'.to_sym)
+  expect(expected[:attributes]).to have_key('author-title'.to_sym)
+  expect(expected[:attributes]).to have_key('author-image'.to_sym)
 end


### PR DESCRIPTION
This PR relates to the following PT task: https://www.pivotaltracker.com/story/show/171645797

Two new fields were added to the Dashboard model, one referring the title of the author of the dashboard, and another containing an image for that same author.

Related docs PR: https://github.com/resource-watch/doc-api/pull/132 