### PR TITLE
add terraform module to create database and role

### DIFF
--- a/terraform/docker/docker-compose.yml
+++ b/terraform/docker/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+services:
+  terraform:
+    image: globalforestwatch/terraform:1.2.2
+    volumes:
+      - ../../:/usr/local/src
+      - $HOME/.aws:/root/.aws:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - ENV
+      - PROJECT=wri-api
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_REGION
+      - DEBUG=1
+      - CLOUDFLARE_EMAIL
+      - CLOUDFLARE_API_KEY
+    working_dir: /usr/local/src
+    entrypoint: infra

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,65 @@
+terraform {
+  backend "s3" {
+    region         = "us-east-1"
+    key            = "resource-watch-manager.tfstate"
+    dynamodb_table = "aws-locks"
+    encrypt        = true
+  }
+}
+# import core state
+data "terraform_remote_state" "core" {
+  backend = "s3"
+  config = {
+    bucket = local.tf_state_bucket
+    region = "us-east-1"
+    key    = "core.tfstate"
+  }
+}
+# some local
+locals {
+  bucket_suffix      = var.environment == "production" ? "" : "-${var.environment}"
+  tf_state_bucket    = "wri-api-terraform${local.bucket_suffix}"
+  tags               = data.terraform_remote_state.core.outputs.tags
+  name_suffix        = terraform.workspace == "default" ? "" : "-${terraform.workspace}"
+  project            = "resource-watch-manager"
+  create_db_sql      = "SELECT 'CREATE DATABASE ${var.database}' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '${var.database}')\\gexec"
+  drop_db_sql        = "DROP DATABASE IF EXISTS ${var.database};"
+  create_role_sql    = "DO $body BEGIN CREATE ROLE ${var.user_name} LOGIN PASSWORD '${var.password}'; EXCEPTION WHEN others THEN RAISE NOTICE '${var.user_name} role exists, not re-creating'; END $body$"
+  drop_role_sql      = "DROP ROLE IF EXISTS ${var.user_name};"
+  superuser          = jsondecode(data.terraform_remote_state.core.outputs.postgres_writer_secret_string)["username"]
+  superuser_password = jsondecode(data.terraform_remote_state.core.outputs.postgres_writer_secret_string)["password"]
+  host               = jsondecode(data.terraform_remote_state.core.outputs.postgres_writer_secret_string)["host"]
+  port               = jsondecode(data.terraform_remote_state.core.outputs.postgres_writer_secret_string)["port"]
+}
+
+
+
+resource "null_resource" "database" {
+  # Changes to username, password or database triggers provisioner
+  triggers = {
+    role     = var.user_name
+    password = var.password
+    database = var.database
+  }
+
+  connection {
+    host = data.terraform_remote_state.core.outputs.bastion_dns
+    user = "ubuntu"
+    private_key = "~/.certificates/tmaschler_gfw.pem"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "PGPASSWORD=${local.superuser_password} psql -h ${local.host} -p ${local.port} -U ${local.superuser} -c ${local.create_db_sql}",
+      "PGPASSWORD=${local.superuser_password} psql -h ${local.host} -p ${local.port} -U ${local.superuser} -c ${local.create_role_sql}",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    when    = destroy
+    inline = [
+      "PGPASSWORD=${local.superuser_password} psql -h ${local.host} -p ${local.port} -U ${local.superuser} -c ${local.drop_db_sql}",
+      "PGPASSWORD=${local.superuser_password} psql -h ${local.host} -p ${local.port} -U ${local.superuser} -c ${local.drop_role_sql}",
+    ]
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,20 @@
+variable "environment" {
+  type = string
+}
+
+variable "user_name" {
+  type = string
+  default = "resouce-watch-manager"
+  description = "Name of database user"
+}
+
+variable "password" {
+  type = string
+  description = "Password for database user"
+}
+
+variable "database" {
+  type = string
+  default = "resource-watch-manager"
+  description = "Database name"
+}

--- a/terraform/vars/backend-dev.tfvars
+++ b/terraform/vars/backend-dev.tfvars
@@ -1,0 +1,1 @@
+bucket = "wri-api-terraform-dev"

--- a/terraform/vars/backend-production.tfvars
+++ b/terraform/vars/backend-production.tfvars
@@ -1,0 +1,1 @@
+bucket = "wri-api-terraform"

--- a/terraform/vars/backend-staging.tfvars
+++ b/terraform/vars/backend-staging.tfvars
@@ -1,0 +1,1 @@
+bucket = "wri-api-terraform-staging"

--- a/terraform/vars/terraform-dev.tfvars
+++ b/terraform/vars/terraform-dev.tfvars
@@ -1,0 +1,1 @@
+environment                 = "dev"

--- a/terraform/vars/terraform-production.tfvars
+++ b/terraform/vars/terraform-production.tfvars
@@ -1,0 +1,1 @@
+environment                 = "production"

--- a/terraform/vars/terraform-staging.tfvars
+++ b/terraform/vars/terraform-staging.tfvars
@@ -1,0 +1,1 @@
+environment                 = "staging"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+  required_version = "~> 0.13.0"
+}


### PR DESCRIPTION
@tiagojsag I am still trying to figure out how to best create role and database from outside the VPC. The terraform postgresql provider requires to have direct access to the database server.

Here I am executing a shell script on the bastion host via ssh.
Do you have other ideas on how to do this?