### PR TITLE
RW Manager FAQ pages - multi-env on current list endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ end
 
 group :test do
   gem 'database_cleaner'
+  gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,10 @@ GEM
       bundler (>= 1.3.0)
       railties (= 5.1.6.2)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -380,6 +384,7 @@ DEPENDENCIES
   rack-cors
   rack-reverse-proxy
   rails (~> 5.1.6)
+  rails-controller-testing
   rspec-rails
   rubocop
   sendgrid-ruby
@@ -397,4 +402,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   2.0.2
+   2.2.25

--- a/app/controllers/api/faqs_controller.rb
+++ b/app/controllers/api/faqs_controller.rb
@@ -8,7 +8,7 @@ module Api
 
     def index
       @faqs = Faq.all
-      @faqs = @faqs.where(environment: @environments) if defined? @environments
+      @faqs = @faqs.where(environment: @environments)
       render json: @faqs
     end
 

--- a/app/controllers/api/faqs_controller.rb
+++ b/app/controllers/api/faqs_controller.rb
@@ -4,9 +4,12 @@ module Api
   # API class for the Faqs Resource
   class FaqsController < ApiController
     before_action :set_faq, only: %i[show update destroy]
+    before_action :set_environment, only: [:index]
 
     def index
-      render json: Faq.all
+      @faqs = Faq.all
+      @faqs = @faqs.where(environment: @environments) if defined? @environments
+      render json: @faqs
     end
 
     def show

--- a/app/controllers/api/faqs_controller.rb
+++ b/app/controllers/api/faqs_controller.rb
@@ -58,7 +58,7 @@ module Api
     end
 
     def faq_params
-      ParamsHelper.permit(params, :question, :answer, :order)
+      ParamsHelper.permit(params, :question, :answer, :order, :environment)
     rescue
       nil
     end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -64,6 +64,15 @@ class ApiController < ActionController::API
     render json: { errors: [{ status: '404', title: 'Record not found' }] }, status: 404
   end
 
+  def set_environment
+    return true unless params[:environment]
+
+    environments = params[:environment].split(',').map(&:downcase).map(&:strip) & Environment::OPTIONS
+    return true unless environments.compact.any?
+
+    @environments = environments
+  end
+
   def set_private_cache_header
     expires_in 24.hours
   end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -65,6 +65,7 @@ class ApiController < ActionController::API
   end
 
   def set_environment
+    @environments = [Environment::PRODUCTION]
     return true unless params[:environment]
 
     environments = params[:environment].split(',').map(&:downcase).map(&:strip) & Environment::OPTIONS

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -68,7 +68,7 @@ class ApiController < ActionController::API
     @environments = [Environment::PRODUCTION]
     return true unless params[:environment]
 
-    environments = params[:environment].split(',').map(&:downcase).map(&:strip) & Environment::OPTIONS
+    environments = params[:environment].split(',').map(&:downcase).map(&:strip)
     return true unless environments.compact.any?
 
     @environments = environments

--- a/app/models/concerns/environment.rb
+++ b/app/models/concerns/environment.rb
@@ -6,10 +6,10 @@ module Environment
   STAGING = 'staging'.freeze
   PRODUCTION = 'production'.freeze
   PREPRODUCTION = 'preproduction'.freeze
-  OPTIONS = [STAGING, PRODUCTION, PREPRODUCTION].freeze
 
   included do
-    # TODO: should this be just set to production if not provided?
-    validates :environment, presence: true, inclusion: OPTIONS
+    # default to production if environment not specified
+    before_validation(on: :create) { self.environment ||= PRODUCTION }
+    validates :environment, presence: true
   end
 end

--- a/app/models/concerns/environment.rb
+++ b/app/models/concerns/environment.rb
@@ -3,9 +3,7 @@ require 'active_support/concern'
 module Environment
   extend ActiveSupport::Concern
 
-  STAGING = 'staging'.freeze
   PRODUCTION = 'production'.freeze
-  PREPRODUCTION = 'preproduction'.freeze
 
   included do
     # default to production if environment not specified

--- a/app/models/concerns/environment.rb
+++ b/app/models/concerns/environment.rb
@@ -1,0 +1,15 @@
+require 'active_support/concern'
+
+module Environment
+  extend ActiveSupport::Concern
+
+  STAGING = 'staging'.freeze
+  PRODUCTION = 'production'.freeze
+  PREPRODUCTION = 'preproduction'.freeze
+  OPTIONS = [STAGING, PRODUCTION, PREPRODUCTION].freeze
+
+  included do
+    # TODO: should this be just set to production if not provided?
+    validates :environment, presence: true, inclusion: OPTIONS
+  end
+end

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -13,6 +13,8 @@
 
 # Model for Partner
 class Faq < ApplicationRecord
+  include Environment
+
   validates_presence_of :question
   validates_presence_of :answer
 

--- a/db/migrate/20210813061800_add_environment_to_faqs.rb
+++ b/db/migrate/20210813061800_add_environment_to_faqs.rb
@@ -1,0 +1,9 @@
+class AddEnvironmentToFaqs < ActiveRecord::Migration[5.1]
+  def change
+    add_column :faqs, :environment, :text, default: Environment::PRODUCTION
+    # apply default to existing records
+    execute "UPDATE faqs SET environment='#{Environment::PRODUCTION}'"
+    # set NOT NULL
+    change_column_null :faqs, :environment, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200319105154) do
+ActiveRecord::Schema.define(version: 20210813061800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 20200319105154) do
     t.integer "order"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "environment", default: "production", null: false
   end
 
   create_table "partners", id: :serial, force: :cascade do |t|

--- a/spec/controllers/api/faqs_controller_spec.rb
+++ b/spec/controllers/api/faqs_controller_spec.rb
@@ -10,10 +10,10 @@ describe Api::FaqsController, type: :controller do
       @preproduction_faq = FactoryBot.create(:faq_preproduction)
     end
 
-    it 'returns unfiltered list' do
+    it 'filters by production env when no env filter specified' do
       get :index, params: {}
       faq_ids = assigns(:faqs).map(&:id)
-      expect(faq_ids).to eq([@staging_faq.id, @production_faq.id, @preproduction_faq.id])
+      expect(faq_ids).to eq([@production_faq.id])
     end
 
     it 'filters by single env' do
@@ -31,7 +31,7 @@ describe Api::FaqsController, type: :controller do
     it 'ignores bogus env filter' do
       get :index, params: {environment: 'ZONK,,,'}
       faq_ids = assigns(:faqs).map(&:id)
-      expect(faq_ids).to eq([@staging_faq.id, @production_faq.id, @preproduction_faq.id])
+      expect(faq_ids).to eq([@production_faq.id])
     end
 
     it 'returns list filtered by multiple envs' do

--- a/spec/controllers/api/faqs_controller_spec.rb
+++ b/spec/controllers/api/faqs_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Api::FaqsController, type: :controller do
+  describe 'GET #index' do
+    before(:each) do
+      @staging_faq = FactoryBot.create(:faq_staging)
+      @production_faq = FactoryBot.create(:faq_production)
+      @preproduction_faq = FactoryBot.create(:faq_preproduction)
+    end
+
+    it 'returns unfiltered list' do
+      get :index, params: {}
+      faq_ids = assigns(:faqs).map(&:id)
+      expect(faq_ids).to eq([@staging_faq.id, @production_faq.id, @preproduction_faq.id])
+    end
+
+    it 'filters by single env' do
+      get :index, params: {environment: Environment::STAGING}
+      faq_ids = assigns(:faqs).map(&:id)
+      expect(faq_ids).to eq([@staging_faq.id])
+    end
+
+    it 'filters by env with weird spellings' do
+      get :index, params: {environment: 'STAGing ,,,'}
+      faq_ids = assigns(:faqs).map(&:id)
+      expect(faq_ids).to eq([@staging_faq.id])
+    end
+
+    it 'ignores bogus env filter' do
+      get :index, params: {environment: 'ZONK,,,'}
+      faq_ids = assigns(:faqs).map(&:id)
+      expect(faq_ids).to eq([@staging_faq.id, @production_faq.id, @preproduction_faq.id])
+    end
+
+    it 'returns list filtered by multiple envs' do
+      get :index, params: {environment: [Environment::PRODUCTION, Environment::PREPRODUCTION].join(',')}
+      faq_ids = assigns(:faqs).map(&:id)
+      expect(faq_ids).to eq([@production_faq.id, @preproduction_faq.id])
+    end
+  end
+end

--- a/spec/controllers/api/faqs_controller_spec.rb
+++ b/spec/controllers/api/faqs_controller_spec.rb
@@ -28,10 +28,10 @@ describe Api::FaqsController, type: :controller do
       expect(faq_ids).to eq([@staging_faq.id])
     end
 
-    it 'ignores bogus env filter' do
-      get :index, params: {environment: 'ZONK,,,'}
+    it 'returns no results if completely messed up env filter' do
+      get :index, params: {environment: 'pre-production'}
       faq_ids = assigns(:faqs).map(&:id)
-      expect(faq_ids).to eq([@production_faq.id])
+      expect(faq_ids).to eq([])
     end
 
     it 'returns list filtered by multiple envs' do

--- a/spec/factories/faqs.rb
+++ b/spec/factories/faqs.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :faq do
+    question { FFaker::LoremIE.question }
+    answer { FFaker::LoremIE.paragraph }
+    sequence(:order)
+
+    trait :staging do
+      environment { Environment::STAGING }
+    end
+
+    trait :production do
+      environment { Environment::PRODUCTION }
+    end
+
+    trait :preproduction do
+      environment { Environment::PREPRODUCTION }
+    end
+
+    factory :faq_staging, traits: [:staging]
+    factory :faq_production, traits: [:production]
+    factory :faq_preproduction, traits: [:preproduction]
+  end
+end

--- a/spec/factories/faqs.rb
+++ b/spec/factories/faqs.rb
@@ -4,20 +4,10 @@ FactoryBot.define do
     answer { FFaker::LoremIE.paragraph }
     sequence(:order)
 
-    trait :staging do
-      environment { Environment::STAGING }
-    end
-
     trait :production do
       environment { Environment::PRODUCTION }
     end
 
-    trait :preproduction do
-      environment { Environment::PREPRODUCTION }
-    end
-
-    factory :faq_staging, traits: [:staging]
     factory :faq_production, traits: [:production]
-    factory :faq_preproduction, traits: [:preproduction]
   end
 end

--- a/spec/models/insight_test.rb
+++ b/spec/models/insight_test.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'test_helper'
-
-class InsightTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/RER-29?atlOrigin=eyJpIjoiZjY3ZDZiZDRlMTI0NDljOWI2ZTU4OTgxMTNjNjMwM2QiLCJwIjoiaiJ9

Questions:
- is it correct to set a default to production and update all existing records? - that seems to be the conclusion based on [the docs](https://resource-watch.github.io/doc-api/concepts.html#environments)
- is it correct to have the inclusion validation in the model? (staging, production, preproduction) - I removed that eventually, because it seems the user should be able to use whatever environment. Effectively, only the 'production' environment is a special value?