### PR TITLE
RW Manager partners - multi-env on current list endpoints

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -66,9 +66,9 @@ class ApiController < ActionController::API
 
   def set_environment
     @environments = [Environment::PRODUCTION]
-    return true unless params[:environment]
+    return true unless params[:env]
 
-    environments = params[:environment].split(',').map(&:downcase).map(&:strip)
+    environments = params[:env].split(',').map(&:downcase).map(&:strip)
     return true unless environments.compact.any?
 
     @environments = environments

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -39,6 +39,7 @@
 
 # Model for Partner
 class Partner < ApplicationRecord
+  include Environment
   extend FriendlyId
   friendly_id :name, use: %i[slugged finders]
 
@@ -79,9 +80,6 @@ class Partner < ApplicationRecord
   scope :by_published, ->(published) { where(published: published) }
   scope :by_featured, ->(featured) { where(featured: featured) }
   scope :by_partner_type, ->(by_partner_type) { where(by_partner_type: by_partner_type) }
-  scope :production, -> { where(production: true) }
-  scope :pre_production, -> { where(pre_production: true) }
-  scope :staging, -> { where(staging: true) }
 
   def self.fetch_all(options = {})
     partners = Partner.all
@@ -90,19 +88,6 @@ class Partner < ApplicationRecord
       partners = partners.by_featured(options[:filter][:featured]) if options[:filter][:featured]
       partners = partners.by_partner_type(options[:filter][:by_partner_type]) if options[:filter][:by_partner_type]
     end
-
-    if options[:env]
-      environments = options[:env].split(',')
-
-      ids = environments.map do |env|
-        Partner.where(env => true)
-      end.flatten.uniq.pluck(:id)
-
-      partners = partners.where(id: ids)
-    else
-      partners = partners.production
-    end
-    
     partners = partners.order(get_order(options))
   end
 

--- a/app/serializers/faq_serializer.rb
+++ b/app/serializers/faq_serializer.rb
@@ -13,5 +13,5 @@
 
 # Faq serializer
 class FaqSerializer < ActiveModel::Serializer
-  attributes :id, :question, :answer, :order
+  attributes :id, :question, :answer, :order, :environment
 end

--- a/app/serializers/partner_serializer.rb
+++ b/app/serializers/partner_serializer.rb
@@ -42,7 +42,7 @@ class PartnerSerializer < ActiveModel::Serializer
   attributes :id, :name, :slug, :summary, :body,
              :contact_email, :contact_name, :website, :featured,
              :logo, :white_logo, :cover, :icon, :partner_type, :published,
-             :production, :preproduction, :staging
+             :environment
 
   link(:self) { api_partner_path(object) }
 

--- a/db/migrate/20210813061800_add_environment_to_faqs.rb
+++ b/db/migrate/20210813061800_add_environment_to_faqs.rb
@@ -1,8 +1,12 @@
 class AddEnvironmentToFaqs < ActiveRecord::Migration[5.1]
   def change
     add_column :faqs, :environment, :text, default: Environment::PRODUCTION
-    # apply default to existing records
-    execute "UPDATE faqs SET environment='#{Environment::PRODUCTION}'"
+    reversible do |dir|
+      dir.up do
+        # apply default to existing records
+        execute "UPDATE faqs SET environment='#{Environment::PRODUCTION}'"
+      end
+    end
     # set NOT NULL
     change_column_null :faqs, :environment, false
   end

--- a/db/migrate/20210823071130_add_environment_to_partners.rb
+++ b/db/migrate/20210823071130_add_environment_to_partners.rb
@@ -1,0 +1,20 @@
+class AddEnvironmentToPartners < ActiveRecord::Migration[5.1]
+  def change
+    add_column :partners, :environment, :text, default: Environment::PRODUCTION
+    reversible do |dir|
+      dir.up do
+        # update existing records according to old env flags or apply default
+        execute <<~SQL
+          UPDATE partners
+          SET environment = CASE
+            WHEN preproduction THEN 'preproduction'
+            WHEN staging THEN 'staging'
+            ELSE '#{Environment::PRODUCTION}'
+          END
+        SQL
+      end
+    end
+    # set NOT NULL
+    change_column_null :partners, :environment, false
+  end
+end

--- a/db/migrate/20210823094212_remove_old_environment_flags_from_partners.rb
+++ b/db/migrate/20210823094212_remove_old_environment_flags_from_partners.rb
@@ -1,0 +1,8 @@
+class RemoveOldEnvironmentFlagsFromPartners < ActiveRecord::Migration[5.1]
+  def change
+    # environment has been populated based on the values of these columns in previous migration
+    remove_column :partners, :production, :boolean, default: true
+    remove_column :partners, :preproduction, :boolean, default: false
+    remove_column :partners, :staging, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210813061800) do
+ActiveRecord::Schema.define(version: 20210823094212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,9 +95,7 @@ ActiveRecord::Schema.define(version: 20210813061800) do
     t.datetime "cover_updated_at"
     t.string "website"
     t.string "partner_type"
-    t.boolean "production", default: true
-    t.boolean "preproduction", default: false
-    t.boolean "staging", default: false
+    t.text "environment", default: "production", null: false
     t.index ["slug"], name: "index_partners_on_slug"
   end
 

--- a/spec/controllers/api/faqs_controller_spec.rb
+++ b/spec/controllers/api/faqs_controller_spec.rb
@@ -17,25 +17,25 @@ describe Api::FaqsController, type: :controller do
     end
 
     it 'filters by single env' do
-      get :index, params: {environment: 'staging'}
+      get :index, params: {env: 'staging'}
       faq_ids = assigns(:faqs).map(&:id)
       expect(faq_ids).to eq([@staging_faq.id])
     end
 
     it 'filters by multiple envs' do
-      get :index, params: {environment: [Environment::PRODUCTION, 'preproduction'].join(',')}
+      get :index, params: {env: [Environment::PRODUCTION, 'preproduction'].join(',')}
       faq_ids = assigns(:faqs).map(&:id)
       expect(faq_ids).to eq([@production_faq.id, @preproduction_faq.id])
     end
 
     it 'filters by env with weird spellings' do
-      get :index, params: {environment: 'STAGing ,,,'}
+      get :index, params: {env: 'STAGing ,,,'}
       faq_ids = assigns(:faqs).map(&:id)
       expect(faq_ids).to eq([@staging_faq.id])
     end
 
     it "returns no results if specified env doesn't match anything" do
-      get :index, params: {environment: 'pre-production'}
+      get :index, params: {env: 'pre-production'}
       faq_ids = assigns(:faqs).map(&:id)
       expect(faq_ids).to eq([])
     end
@@ -98,6 +98,19 @@ describe Api::FaqsController, type: :controller do
           expect(@staging_faq.reload.environment).to eq(Environment::PRODUCTION)
         end
       end
+    end
+  end
+
+  describe 'DELETE #faq' do
+    before(:each) do
+      @faq = FactoryBot.create :faq, environment: 'staging'
+    end
+
+    it 'with no user details should produce a 401 error' do
+      delete :destroy, params: {id: @faq.id}
+
+      expect(response.status).to eq(401)
+      expect(response.body).to include "Unauthorized"
     end
   end
 end

--- a/spec/controllers/api/partners_controller_spec.rb
+++ b/spec/controllers/api/partners_controller_spec.rb
@@ -3,32 +3,71 @@
 require 'spec_helper'
 
 describe Api::PartnersController, type: :controller do
-  describe 'GET #partner' do
+  describe 'GET #index' do
     before(:each) do
-      @partner = FactoryBot.create :partner
-      get :show, params: { id: @partner.id }
+      @production_partner = FactoryBot.create(:partner_production)
+      @staging_partner = FactoryBot.create(:partner, environment: 'staging')
+      @preproduction_partner = FactoryBot.create(:partner, environment: 'preproduction')
     end
 
-    it 'returns the information about a partner on a hash' do
-      partner_response = json_response
-      expect(partner_response.dig(:data, :attributes, :name)).to eql @partner.name
+    it 'filters by production env when no env filter specified' do
+      get :index, params: {}
+      partner_ids = assigns(:partners).map(&:id)
+      expect(partner_ids).to eq([@production_partner.id])
     end
 
-    it { should respond_with 200 }
+    it 'filters by single env' do
+      get :index, params: {env: 'staging'}
+      partner_ids = assigns(:partners).map(&:id)
+      expect(partner_ids).to eq([@staging_partner.id])
+    end
+
+    it 'filters by multiple envs' do
+      get :index, params: {env: [Environment::PRODUCTION, 'preproduction'].join(',')}
+      partner_ids = assigns(:partners).map(&:id)
+      expect(partner_ids).to eq([@production_partner.id, @preproduction_partner.id])
+    end
+
+    it 'filters by env with weird spellings' do
+      get :index, params: {env: 'STAGing ,,,'}
+      partner_ids = assigns(:partners).map(&:id)
+      expect(partner_ids).to eq([@staging_partner.id])
+    end
+
+    it "returns no results if specified env doesn't match anything" do
+      get :index, params: {env: 'pre-production'}
+      partner_ids = assigns(:partners).map(&:id)
+      expect(partner_ids).to eq([])
+    end
   end
 
-  describe 'GET #partner by slug' do
-    before(:each) do
-      @partner = FactoryBot.create :partner
-      get :show, params: { id: @partner.slug }
+  describe 'GET #partner' do
+    before(:each) { @partner = FactoryBot.create :partner_production }
+    context 'by id' do
+      before(:each) do
+        get :show, params: {id: @partner.id}
+      end
+
+      it 'returns the information about a partner on a hash' do
+        partner_response = json_response
+        expect(partner_response.dig(:data, :attributes, :name)).to eql @partner.name
+      end
+
+      it { should respond_with 200 }
     end
 
-    it 'returns the information about a partner on a hash' do
-      partner_response = json_response
-      expect(partner_response.dig(:data, :attributes, :name)).to eql @partner.name
-    end
+    context 'by slug' do
+      before(:each) do
+        get :show, params: {id: @partner.slug}
+      end
 
-    it { should respond_with 200 }
+      it 'returns the information about a partner on a hash' do
+        partner_response = json_response
+        expect(partner_response.dig(:data, :attributes, :name)).to eql @partner.name
+      end
+
+      it { should respond_with 200 }
+    end
   end
 
   describe 'POST #partner' do
@@ -38,32 +77,70 @@ describe Api::PartnersController, type: :controller do
       expect(response.status).to eq(401)
       expect(response.body).to include "Unauthorized"
     end
+
+    context 'environment' do
+      it 'sets environment to default if not specified' do
+        VCR.use_cassette('user_user') do
+          request.headers["Authorization"] = "abd"
+          post :create, params: {data: {attributes: {name: 'foo'}}}
+          partner = Partner.find_by_name('foo')
+          expect(partner.environment).to eq(Environment::PRODUCTION)
+        end
+      end
+
+      it 'sets environment if specified' do
+        VCR.use_cassette('user_user') do
+          request.headers["Authorization"] = "abd"
+          post :create, params: {data: {attributes: {name: 'foo', environment: 'potato'}}}
+          partner = Partner.find_by_name('foo')
+          expect(partner.environment).to eq('potato')
+        end
+      end
+    end
   end
 
   describe 'PATCH #partner' do
     before(:each) do
-      @partner = FactoryBot.create :partner
+      @partner = FactoryBot.create :partner, environment: 'staging'
     end
 
     it 'with no user details should produce a 401 error' do
-      patch :update, params: {
-        id: @partner[:id]
-      }
+      patch :update, params: {id: @partner.id}
 
       expect(response.status).to eq(401)
       expect(response.body).to include "Unauthorized"
+    end
+
+    context 'environment' do
+      it "doesn't update environment if not specified" do
+        VCR.use_cassette('user_user') do
+          request.headers["Authorization"] = "abd"
+          patch :update, params: {
+            id: @partner.id, data: {attributes: {answer: 'zonk'}}
+          }
+          expect(@partner.reload.environment).to eq('staging')
+        end
+      end
+
+      it "updates environment if specified" do
+        VCR.use_cassette('user_user') do
+          request.headers["Authorization"] = "abd"
+          patch :update, params: {
+            id: @partner.id, data: {attributes: {environment: Environment::PRODUCTION}}
+          }
+          expect(@partner.reload.environment).to eq(Environment::PRODUCTION)
+        end
+      end
     end
   end
 
   describe 'DELETE #partner' do
     before(:each) do
-      @partner = FactoryBot.create :partner
+      @partner = FactoryBot.create :partner, environment: 'staging'
     end
 
     it 'with no user details should produce a 401 error' do
-      delete :destroy, params: {
-        id: @partner[:id]
-      }
+      delete :destroy, params: {id: @partner.id}
 
       expect(response.status).to eq(401)
       expect(response.body).to include "Unauthorized"

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -47,5 +47,11 @@ FactoryBot.define do
     published { FFaker::Boolean.sample }
     featured { FFaker::Boolean.sample }
     website { FFaker::Internet.http_url }
+
+    trait :production do
+      environment { Environment::PRODUCTION }
+    end
+
+    factory :partner_production, traits: [:production]
   end
 end

--- a/spec/models/faq_spec.rb
+++ b/spec/models/faq_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Faq, type: :model do
+  describe :create do
+    context 'environment given' do
+      let(:subject) { FactoryBot.create(:faq, environment: 'potato') }
+
+      it 'saves specified environment' do
+        expect(subject.environment).to eq('potato')
+      end
+    end
+
+    context 'environment not given' do
+      let(:subject) { FactoryBot.create(:faq, environment: nil) }
+
+      it 'saves production environment' do
+        expect(subject.environment).to eq(Environment::PRODUCTION)
+      end
+    end
+  end
+end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Partner, type: :model do
+  describe :create do
+    context 'environment given' do
+      let(:subject) { FactoryBot.create(:partner, environment: 'potato') }
+
+      it 'saves specified environment' do
+        expect(subject.environment).to eq('potato')
+      end
+    end
+
+    context 'environment not given' do
+      let(:subject) { FactoryBot.create(:partner, environment: nil) }
+
+      it 'saves production environment' do
+        expect(subject.environment).to eq(Environment::PRODUCTION)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://vizzuality.atlassian.net/browse/RER-26?atlOrigin=eyJpIjoiZjUwYWFiMmMzNDgzNGEyYjliNmQzOTVlYWJkMjc2MzIiLCJwIjoiaiJ9

https://vizzuality.atlassian.net/browse/RER-35?atlOrigin=eyJpIjoiY2ZiNmIyNWZlMzBhNGNjYThiN2MwNjczNjk3N2Y1MGEiLCJwIjoiaiJ9

Doubts I found when working on the partners controller:
- The previous version of the endpoints in the partners controller allowed to specify the environment via `env` param; I'm afraid that when working on the faqs controller I called the param `environment`. Currently both are accepted, but perhaps it would be better to switch the faqs controller to expect `env`, for simplicity? Or stick with `environment` for consistency with the field name?
- The show / update / destroy actions also check the environment - this is something that was not implemented in faqs, because the task was only about the list, but I guess it should be kept consistent, so I added the same check to faqs - is that right? 
- However, I cannot say I like it. The `update` action is the reason why - if looks clunky you want to update the environment of the resource, you need to pass environment twice into the endpoint, as shown in the spec:
    ```
         patch :update, params: {
            id: @partner.id, environment: 'staging', data: {attributes: {environment: Environment::PRODUCTION}}
         }
    ```
    
    the first `environment` (previously `env`) is there so that the `set_partner` method finds the resource, the second is in order to specify the new environment of the resource (previously `production` | `preproduction` | `staging`). Let me know if this is expected?
- finally, when migrating from the old flags, the resource now has a single environment assigned; somehow that's how I understood it should be, but it is not compatible with the old flags, which allowed the resource to exist in multiple environments. So double checking about this now to avoid unintentional data loss in case we actually still need to support multiple environments. 