### PR TITLE
Fix/cleanup after environment tasks

### DIFF
--- a/app/models/content_image.rb
+++ b/app/models/content_image.rb
@@ -3,15 +3,19 @@
 #
 # Table name: content_images
 #
-#  id                 :bigint(8)        not null, primary key
-#  imageable_id       :integer
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  image_file_name    :string
+#  id                 :bigint           not null, primary key
 #  image_content_type :string
+#  image_file_name    :string
 #  image_file_size    :integer
 #  image_updated_at   :datetime
 #  imageable_type     :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  imageable_id       :integer
+#
+# Indexes
+#
+#  index_content_images_on_imageable_type_and_imageable_id  (imageable_type,imageable_id)
 #
 
 class ContentImage < ApplicationRecord

--- a/app/models/faq.rb
+++ b/app/models/faq.rb
@@ -3,12 +3,13 @@
 #
 # Table name: faqs
 #
-#  id         :bigint(8)        not null, primary key
-#  question   :string           not null
-#  answer     :text             not null
-#  order      :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :bigint           not null, primary key
+#  answer      :text             not null
+#  environment :text             default("production"), not null
+#  order       :integer
+#  question    :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #
 
 # Model for Partner

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -4,37 +4,39 @@
 # Table name: partners
 #
 #  id                      :integer          not null, primary key
-#  name                    :string
-#  slug                    :string
-#  summary                 :string
-#  contact_name            :string
-#  contact_email           :string
 #  body                    :text
-#  logo_file_name          :string
-#  logo_content_type       :string
-#  logo_file_size          :integer
-#  logo_updated_at         :datetime
-#  white_logo_file_name    :string
-#  white_logo_content_type :string
-#  white_logo_file_size    :integer
-#  white_logo_updated_at   :datetime
-#  icon_file_name          :string
-#  icon_content_type       :string
-#  icon_file_size          :integer
-#  icon_updated_at         :datetime
-#  published               :boolean
-#  featured                :boolean
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  cover_file_name         :string
+#  contact_email           :string
+#  contact_name            :string
 #  cover_content_type      :string
+#  cover_file_name         :string
 #  cover_file_size         :integer
 #  cover_updated_at        :datetime
-#  website                 :string
+#  environment             :text             default("production"), not null
+#  featured                :boolean          default(FALSE)
+#  icon_content_type       :string
+#  icon_file_name          :string
+#  icon_file_size          :integer
+#  icon_updated_at         :datetime
+#  logo_content_type       :string
+#  logo_file_name          :string
+#  logo_file_size          :integer
+#  logo_updated_at         :datetime
+#  name                    :string
 #  partner_type            :string
-#  production              :boolean          default(TRUE)
-#  preproduction           :boolean          default(FALSE)
-#  staging                 :boolean          default(FALSE)
+#  published               :boolean          default(FALSE)
+#  slug                    :string
+#  summary                 :string
+#  website                 :string
+#  white_logo_content_type :string
+#  white_logo_file_name    :string
+#  white_logo_file_size    :integer
+#  white_logo_updated_at   :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# Indexes
+#
+#  index_partners_on_slug  (slug)
 #
 
 # Model for Partner

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,14 +3,18 @@
 #
 # Table name: profiles
 #
-#  id                  :bigint(8)        not null, primary key
-#  user_id             :string
-#  avatar_file_name    :string
+#  id                  :bigint           not null, primary key
 #  avatar_content_type :string
+#  avatar_file_name    :string
 #  avatar_file_size    :integer
 #  avatar_updated_at   :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  user_id             :string
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
 #
 
 class Profile < ApplicationRecord

--- a/app/models/temporary_content_image.rb
+++ b/app/models/temporary_content_image.rb
@@ -3,13 +3,13 @@
 #
 # Table name: temporary_content_images
 #
-#  id                 :bigint(8)        not null, primary key
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  image_file_name    :string
+#  id                 :bigint           not null, primary key
 #  image_content_type :string
+#  image_file_name    :string
 #  image_file_size    :integer
 #  image_updated_at   :datetime
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
 #
 
 class TemporaryContentImage < ApplicationRecord

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -3,22 +3,22 @@
 #
 # Table name: topics
 #
-#  id                 :bigint(8)        not null, primary key
-#  name               :string
-#  slug               :string
-#  description        :string
+#  id                 :bigint           not null, primary key
+#  application        :string           default(["\"rw\""]), not null, is an Array
 #  content            :text
-#  published          :boolean
-#  summary            :string
-#  private            :boolean          default(TRUE)
-#  user_id            :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  photo_file_name    :string
+#  description        :string
+#  name               :string
 #  photo_content_type :string
+#  photo_file_name    :string
 #  photo_file_size    :integer
 #  photo_updated_at   :datetime
-#  application        :string           default(["\"rw\""]), not null, is an Array
+#  private            :boolean          default(TRUE)
+#  published          :boolean
+#  slug               :string
+#  summary            :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :string
 #
 
 class Topic < ApplicationRecord

--- a/app/serializers/faq_serializer.rb
+++ b/app/serializers/faq_serializer.rb
@@ -3,12 +3,13 @@
 #
 # Table name: faqs
 #
-#  id         :bigint(8)        not null, primary key
-#  question   :string           not null
-#  answer     :text             not null
-#  order      :integer
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :bigint           not null, primary key
+#  answer      :text             not null
+#  environment :text             default("production"), not null
+#  order       :integer
+#  question    :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
 #
 
 # Faq serializer

--- a/app/serializers/partner_serializer.rb
+++ b/app/serializers/partner_serializer.rb
@@ -4,37 +4,39 @@
 # Table name: partners
 #
 #  id                      :integer          not null, primary key
-#  name                    :string
-#  slug                    :string
-#  summary                 :string
-#  contact_name            :string
-#  contact_email           :string
 #  body                    :text
-#  logo_file_name          :string
-#  logo_content_type       :string
-#  logo_file_size          :integer
-#  logo_updated_at         :datetime
-#  white_logo_file_name    :string
-#  white_logo_content_type :string
-#  white_logo_file_size    :integer
-#  white_logo_updated_at   :datetime
-#  icon_file_name          :string
-#  icon_content_type       :string
-#  icon_file_size          :integer
-#  icon_updated_at         :datetime
-#  published               :boolean
-#  featured                :boolean
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  cover_file_name         :string
+#  contact_email           :string
+#  contact_name            :string
 #  cover_content_type      :string
+#  cover_file_name         :string
 #  cover_file_size         :integer
 #  cover_updated_at        :datetime
-#  website                 :string
+#  environment             :text             default("production"), not null
+#  featured                :boolean          default(FALSE)
+#  icon_content_type       :string
+#  icon_file_name          :string
+#  icon_file_size          :integer
+#  icon_updated_at         :datetime
+#  logo_content_type       :string
+#  logo_file_name          :string
+#  logo_file_size          :integer
+#  logo_updated_at         :datetime
+#  name                    :string
 #  partner_type            :string
-#  production              :boolean          default(TRUE)
-#  preproduction           :boolean          default(FALSE)
-#  staging                 :boolean          default(FALSE)
+#  published               :boolean          default(FALSE)
+#  slug                    :string
+#  summary                 :string
+#  website                 :string
+#  white_logo_content_type :string
+#  white_logo_file_name    :string
+#  white_logo_file_size    :integer
+#  white_logo_updated_at   :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# Indexes
+#
+#  index_partners_on_slug  (slug)
 #
 
 # Partner serializer

--- a/app/serializers/profile_serializer.rb
+++ b/app/serializers/profile_serializer.rb
@@ -3,14 +3,18 @@
 #
 # Table name: profiles
 #
-#  id                  :bigint(8)        not null, primary key
-#  user_id             :string
-#  avatar_file_name    :string
+#  id                  :bigint           not null, primary key
 #  avatar_content_type :string
+#  avatar_file_name    :string
 #  avatar_file_size    :integer
 #  avatar_updated_at   :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  user_id             :string
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
 #
 
 # Profile Serializer

--- a/app/serializers/topic_serializer.rb
+++ b/app/serializers/topic_serializer.rb
@@ -3,22 +3,22 @@
 #
 # Table name: topics
 #
-#  id                 :bigint(8)        not null, primary key
-#  name               :string
-#  slug               :string
-#  description        :string
+#  id                 :bigint           not null, primary key
+#  application        :string           default(["\"rw\""]), not null, is an Array
 #  content            :text
-#  published          :boolean
-#  summary            :string
-#  private            :boolean          default(TRUE)
-#  user_id            :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  photo_file_name    :string
+#  description        :string
+#  name               :string
 #  photo_content_type :string
+#  photo_file_name    :string
 #  photo_file_size    :integer
 #  photo_updated_at   :datetime
-#  application        :string           default(["\"rw\""]), not null, is an Array
+#  private            :boolean          default(TRUE)
+#  published          :boolean
+#  slug               :string
+#  summary            :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :string
 #
 
 class TopicSerializer < ActiveModel::Serializer

--- a/db/migrate/20210823094212_remove_old_environment_flags_from_partners.rb
+++ b/db/migrate/20210823094212_remove_old_environment_flags_from_partners.rb
@@ -1,5 +1,17 @@
 class RemoveOldEnvironmentFlagsFromPartners < ActiveRecord::Migration[5.1]
   def change
+    reversible do |dir|
+      dir.down do
+        # set env flags based on environment value
+        execute <<~SQL
+          UPDATE partners
+          SET production = CASE WHEN environment = '#{Environment::PRODUCTION}' THEN TRUE ELSE FALSE END,
+              preproduction = CASE WHEN environment = 'preproduction' THEN TRUE ELSE FALSE END,
+              staging = CASE WHEN environment = 'staging' THEN TRUE ELSE FALSE END
+        SQL
+      end
+    end
+
     # environment has been populated based on the values of these columns in previous migration
     remove_column :partners, :production, :boolean, default: true
     remove_column :partners, :preproduction, :boolean, default: false

--- a/db/migrate/20210823123210_remove_old_environment_flags_from_tools.rb
+++ b/db/migrate/20210823123210_remove_old_environment_flags_from_tools.rb
@@ -1,5 +1,17 @@
 class RemoveOldEnvironmentFlagsFromTools < ActiveRecord::Migration[5.1]
   def change
+    reversible do |dir|
+      dir.down do
+        # set env flags based on environment value
+        execute <<~SQL
+          UPDATE tools
+          SET production = CASE WHEN environment = '#{Environment::PRODUCTION}' THEN TRUE ELSE FALSE END,
+              preproduction = CASE WHEN environment = 'preproduction' THEN TRUE ELSE FALSE END,
+              staging = CASE WHEN environment = 'staging' THEN TRUE ELSE FALSE END
+        SQL
+      end
+    end
+
     # environment has been populated based on the values of these columns in previous migration
     remove_column :tools, :production, :boolean, default: true
     remove_column :tools, :preproduction, :boolean, default: false

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,57 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/controllers/api/faqs_controller_spec.rb
+++ b/spec/controllers/api/faqs_controller_spec.rb
@@ -41,6 +41,26 @@ describe Api::FaqsController, type: :controller do
     end
   end
 
+  describe 'GET #show' do
+    before(:each) do
+      @faq = FactoryBot.create :faq_production
+      get :show, params: {id: @faq.id}
+    end
+
+    it 'returns the information about a faq on a hash' do
+      faq_response = json_response
+      expect(faq_response.dig(:data, :attributes, :question)).to eql @faq.question
+    end
+
+    it 'returns environment' do
+      faq_response = json_response
+      expect(faq_response.dig(:data, :attributes, :environment)).to eql @faq.environment
+    end
+
+    it { should respond_with 200 }
+  end
+
+
   describe 'POST #create' do
     it 'with no user details should produce a 401 error' do
       post :create

--- a/spec/controllers/api/partners_controller_spec.rb
+++ b/spec/controllers/api/partners_controller_spec.rb
@@ -53,6 +53,11 @@ describe Api::PartnersController, type: :controller do
         expect(partner_response.dig(:data, :attributes, :name)).to eql @partner.name
       end
 
+      it 'returns environment' do
+        partner_response = json_response
+        expect(partner_response.dig(:data, :attributes, :environment)).to eql @partner.environment
+      end
+
       it { should respond_with 200 }
     end
 

--- a/spec/controllers/api/tools_controller_spec.rb
+++ b/spec/controllers/api/tools_controller_spec.rb
@@ -53,6 +53,11 @@ describe Api::ToolsController, type: :controller do
         expect(tool_response.dig(:data, :attributes, :title)).to eql @tool.title
       end
 
+      it 'returns environment' do
+        tool_response = json_response
+        expect(tool_response.dig(:data, :attributes, :environment)).to eql @tool.environment
+      end
+
       it { should respond_with 200 }
     end
 

--- a/spec/factories/faqs.rb
+++ b/spec/factories/faqs.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: faqs
+#
+#  id          :bigint           not null, primary key
+#  answer      :text             not null
+#  environment :text             default("production"), not null
+#  order       :integer
+#  question    :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 FactoryBot.define do
   factory :faq do
     question { FFaker::LoremIE.question }

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -4,37 +4,39 @@
 # Table name: partners
 #
 #  id                      :integer          not null, primary key
-#  name                    :string
-#  slug                    :string
-#  summary                 :string
-#  contact_name            :string
-#  contact_email           :string
 #  body                    :text
-#  logo_file_name          :string
-#  logo_content_type       :string
-#  logo_file_size          :integer
-#  logo_updated_at         :datetime
-#  white_logo_file_name    :string
-#  white_logo_content_type :string
-#  white_logo_file_size    :integer
-#  white_logo_updated_at   :datetime
-#  icon_file_name          :string
-#  icon_content_type       :string
-#  icon_file_size          :integer
-#  icon_updated_at         :datetime
-#  published               :boolean
-#  featured                :boolean
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  cover_file_name         :string
+#  contact_email           :string
+#  contact_name            :string
 #  cover_content_type      :string
+#  cover_file_name         :string
 #  cover_file_size         :integer
 #  cover_updated_at        :datetime
-#  website                 :string
+#  environment             :text             default("production"), not null
+#  featured                :boolean          default(FALSE)
+#  icon_content_type       :string
+#  icon_file_name          :string
+#  icon_file_size          :integer
+#  icon_updated_at         :datetime
+#  logo_content_type       :string
+#  logo_file_name          :string
+#  logo_file_size          :integer
+#  logo_updated_at         :datetime
+#  name                    :string
 #  partner_type            :string
-#  production              :boolean          default(TRUE)
-#  preproduction           :boolean          default(FALSE)
-#  staging                 :boolean          default(FALSE)
+#  published               :boolean          default(FALSE)
+#  slug                    :string
+#  summary                 :string
+#  website                 :string
+#  white_logo_content_type :string
+#  white_logo_file_name    :string
+#  white_logo_file_size    :integer
+#  white_logo_updated_at   :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# Indexes
+#
+#  index_partners_on_slug  (slug)
 #
 
 FactoryBot.define do

--- a/spec/factories/topics.rb
+++ b/spec/factories/topics.rb
@@ -4,21 +4,22 @@
 #
 # Table name: topics
 #
-#  id                 :bigint(8)        not null, primary key
-#  name               :string
-#  slug               :string
-#  description        :string
+#  id                 :bigint           not null, primary key
+#  application        :string           default(["\"rw\""]), not null, is an Array
 #  content            :text
-#  published          :boolean
-#  summary            :string
-#  private            :boolean          default(TRUE)
-#  user_id            :string
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
-#  photo_file_name    :string
+#  description        :string
+#  name               :string
 #  photo_content_type :string
+#  photo_file_name    :string
 #  photo_file_size    :integer
 #  photo_updated_at   :datetime
+#  private            :boolean          default(TRUE)
+#  published          :boolean
+#  slug               :string
+#  summary            :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :string
 #
 
 FactoryBot.define do

--- a/spec/models/faq_spec.rb
+++ b/spec/models/faq_spec.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: faqs
+#
+#  id          :bigint           not null, primary key
+#  answer      :text             not null
+#  environment :text             default("production"), not null
+#  order       :integer
+#  question    :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe Faq, type: :model do

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -1,3 +1,43 @@
+# == Schema Information
+#
+# Table name: partners
+#
+#  id                      :integer          not null, primary key
+#  body                    :text
+#  contact_email           :string
+#  contact_name            :string
+#  cover_content_type      :string
+#  cover_file_name         :string
+#  cover_file_size         :integer
+#  cover_updated_at        :datetime
+#  environment             :text             default("production"), not null
+#  featured                :boolean          default(FALSE)
+#  icon_content_type       :string
+#  icon_file_name          :string
+#  icon_file_size          :integer
+#  icon_updated_at         :datetime
+#  logo_content_type       :string
+#  logo_file_name          :string
+#  logo_file_size          :integer
+#  logo_updated_at         :datetime
+#  name                    :string
+#  partner_type            :string
+#  published               :boolean          default(FALSE)
+#  slug                    :string
+#  summary                 :string
+#  website                 :string
+#  white_logo_content_type :string
+#  white_logo_file_name    :string
+#  white_logo_file_size    :integer
+#  white_logo_updated_at   :datetime
+#  created_at              :datetime         not null
+#  updated_at              :datetime         not null
+#
+# Indexes
+#
+#  index_partners_on_slug  (slug)
+#
+
 require 'rails_helper'
 
 RSpec.describe Partner, type: :model do

--- a/test/factories/profiles.rb
+++ b/test/factories/profiles.rb
@@ -3,14 +3,18 @@
 #
 # Table name: profiles
 #
-#  id                  :bigint(8)        not null, primary key
-#  user_id             :string
-#  avatar_file_name    :string
+#  id                  :bigint           not null, primary key
 #  avatar_content_type :string
+#  avatar_file_name    :string
 #  avatar_file_size    :integer
 #  avatar_updated_at   :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  user_id             :string
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
 #
 
 FactoryBot.define do

--- a/test/models/profile_test.rb
+++ b/test/models/profile_test.rb
@@ -3,14 +3,18 @@
 #
 # Table name: profiles
 #
-#  id                  :bigint(8)        not null, primary key
-#  user_id             :string
-#  avatar_file_name    :string
+#  id                  :bigint           not null, primary key
 #  avatar_content_type :string
+#  avatar_file_name    :string
 #  avatar_file_size    :integer
 #  avatar_updated_at   :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  user_id             :string
+#
+# Indexes
+#
+#  index_profiles_on_user_id  (user_id)
 #
 
 require 'test_helper'


### PR DESCRIPTION
This retro-adds some improvements to the environment tasks that only occurred to me when I was half way through, so were not applied to the earlier tasks:
- schema annotations were not updated, because a rake task was missing, so I added that and updated ALL the annotations
- after forgetting for the third time to amend the serializer when replacing the old environment flags with environment, I figured it's a good thing to have a spec for the show action that checks for presence of environment
- I fixed reversing the migrations which remove the old flags, so that if we ever need them back their values will be set based on environment